### PR TITLE
Adding option to eject darkslide on shutter press

### DIFF
--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -144,47 +144,56 @@ void loop() {
 
 camera_state do_state_darkslide (void) {
   camera_state result = STATE_DARKSLIDE;
-  if (digitalRead(PIN_S8) == HIGH && digitalRead(PIN_S9) == LOW){
-    currentPicture = 0; 
-    WritePicture(currentPicture);
-    checkFilmCount();
-    if(myDongle.checkDongle() == 0){
-      openSX70.darkslideEJECT(); 
+  #if SHUTTERDARKSLIDE
+  sw_S1.Update();
+  if ((sw_S1.clicks == -1) || (sw_S1.clicks == 1)){
+  #endif
+    if (digitalRead(PIN_S8) == HIGH && digitalRead(PIN_S9) == LOW){
+      currentPicture = 0; 
+      WritePicture(currentPicture);
+      checkFilmCount();
+      if(myDongle.checkDongle() == 0){
+        openSX70.darkslideEJECT(); 
+      }
+      else{
+        myDongle.dongleLed(GREEN, HIGH); //green uDongle LED on while ejecting Darkslide
+        openSX70.darkslideEJECT();
+        myDongle.dongleLed(GREEN, LOW); //switching off green uDongle LED
+      }
+      #if SIMPLEDEBUG
+        Serial.println("STATE1: EJECT DARK SLIDE");
+        Serial.print("currentPicture on Darkslide eject: ");
+        Serial.println(currentPicture);
+      #endif
+    }
+    
+    if ((selector <= 15) && (myDongle.checkDongle() > 0)){ //((selector <= 15) && (myDongle.checkDongle() > 0))
+      result = STATE_DONGLE;
+      delay(100);
+      BlinkISO();
+      #if STATEDEBUG
+        Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE");
+      #endif
+    }
+    else if ((selector == 100) && (myDongle.checkDongle() == 0)){
+      result = STATE_FLASHBAR;
+
+      #if STATEDEBUG
+        Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE");
+      #endif
     }
     else{
-      myDongle.dongleLed(GREEN, HIGH); //green uDongle LED on while ejecting Darkslide
-      openSX70.darkslideEJECT();
-      myDongle.dongleLed(GREEN, LOW); //switching off green uDongle LED
+      result = STATE_NODONGLE;
+
+      #if STATEDEBUG
+        Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE");
+      #endif
     }
-    #if SIMPLEDEBUG
-      Serial.println("STATE1: EJECT DARK SLIDE");
-      Serial.print("currentPicture on Darkslide eject: ");
-      Serial.println(currentPicture);
-    #endif
+  #if SHUTTERDARKSLIDE
+  sw_S1.Reset();
   }
+  #endif
   
-  if ((selector <= 15) && (myDongle.checkDongle() > 0)){ //((selector <= 15) && (myDongle.checkDongle() > 0))
-    result = STATE_DONGLE;
-    delay(100);
-    BlinkISO();
-    #if STATEDEBUG
-      Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE");
-    #endif
-  }
-  else if ((selector == 100) && (myDongle.checkDongle() == 0)){
-    result = STATE_FLASHBAR;
-
-    #if STATEDEBUG
-      Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE");
-    #endif
-  }
-  else{
-    result = STATE_NODONGLE;
-
-    #if STATEDEBUG
-      Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE");
-    #endif
-  }
   return result;
 }
 

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -162,29 +162,28 @@ camera_state do_state_darkslide (void) {
       Serial.println(currentPicture);
     #endif
   }
+  
+  if ((selector <= 15) && (myDongle.checkDongle() > 0)){ //((selector <= 15) && (myDongle.checkDongle() > 0))
+    result = STATE_DONGLE;
+    delay(100);
+    BlinkISO();
+    #if STATEDEBUG
+      Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE");
+    #endif
+  }
+  else if ((selector == 100) && (myDongle.checkDongle() == 0)){
+    result = STATE_FLASHBAR;
+
+    #if STATEDEBUG
+      Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE");
+    #endif
+  }
   else{
-    if ((selector <= 15) && (myDongle.checkDongle() > 0)){ //((selector <= 15) && (myDongle.checkDongle() > 0))
-      result = STATE_DONGLE;
-      delay(100);
-      BlinkISO();
-      #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE");
-      #endif
-    }
-    else if ((selector == 100) && (myDongle.checkDongle() == 0)){
-      result = STATE_FLASHBAR;
+    result = STATE_NODONGLE;
 
-      #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE");
-      #endif
-    }
-    else{
-      result = STATE_NODONGLE;
-
-      #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE");
-      #endif
-    }
+    #if STATEDEBUG
+      Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE");
+    #endif
   }
   return result;
 }

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -31,7 +31,7 @@
   #define GREEN 6 //DONGLE GREEN LED ADRESS
   #define RED 7   //DONGLE RED LED ADRESS
   #define DOUBLECLICK 0
-  #define SHUTTERDARKSLIDE 1 // makes you press shutter button to eject darkslide. This is to prevent externally powered cameras from firing the darkslide when opening.
+  #define SHUTTERDARKSLIDE 0 // makes you press shutter button to eject darkslide. This is to prevent externally powered cameras from firing the darkslide when opening.
   extern const uint8_t YDelay;
   extern const byte PowerDownDelay; //time it takes to be fully closed
   extern const byte PowerDown; //max 255 = full power/POWERUP mode

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -4,7 +4,7 @@
   //------------DEBUG OPTIONS---------------------------------------------
   #define LIGHMETER_HELPER 1
   //LIGHMETER_HELPER 0  NO helper, 1 for VE helper, 2 future dongle helper
-  #define DEBUG 1
+  #define DEBUG 0
   #define SIMPLEDEBUG 0     //Simple Debug On 1 - Off 0
   #define ADVANCEDEBUG 0    //Simple Debug On 1 - Off 0
   #define BASICDEBUG 0      // Debug of Basic Camera Functions
@@ -22,15 +22,16 @@
   #define TCS3200
   //S1Logic LOW = Alphas, Meroë, Edwin
   //#define S1Logic HIGH //= Sonar 
-  #define S1Logic HIGH
-  #define ALPHA 0
-  #define SONAR 1
+  #define S1Logic LOW
+  #define ALPHA 1
+  #define SONAR 0
   #define ORIGAMI 0
   #define ORIGAMIV1 0 //V1 Version of Origami with inverted Rotaryswitch
   #define UDONGLE 1
   #define GREEN 6 //DONGLE GREEN LED ADRESS
   #define RED 7   //DONGLE RED LED ADRESS
   #define DOUBLECLICK 0
+  #define SHUTTERDARKSLIDE 1 // makes you press shutter button to eject darkslide. This is to prevent externally powered cameras from firing the darkslide when opening.
   extern const uint8_t YDelay;
   extern const byte PowerDownDelay; //time it takes to be fully closed
   extern const byte PowerDown; //max 255 = full power/POWERUP mode


### PR DESCRIPTION
Had a request for this feature. Allows cameras that have constant power from the test points to operate without trying to eject the dark slide every time the camera opens without a pack inserted. 

This is an opt-in option in settings.h. will not affect standard users.