### PR TITLE
Allow project compilation in non case-sensitive OS

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -5,7 +5,7 @@
 #include "sx70_pcb.h"
 //#include "Clickbutton.h"
 #include "settings.h"
-#include "uDongle2.h"
+#include "udongle2.h"
 
 extern bool mEXPFirstRun;
 extern bool multipleExposureMode;

--- a/WORKING/opensx70_lib/camera_functions.h
+++ b/WORKING/opensx70_lib/camera_functions.h
@@ -1,7 +1,7 @@
 #ifndef Camera_h
   #define Camera_h
   #include "Arduino.h"
-  #include "uDongle2.h"
+  #include "udongle2.h"
   class Camera
   {
     public:

--- a/WORKING/opensx70_lib/open_sx70.h
+++ b/WORKING/opensx70_lib/open_sx70.h
@@ -11,7 +11,7 @@
   #include "settings.h"
   #include "camera_functions.h"
   //#include "ClickButton.h"
-  #include "uDongle2.h"
+  #include "udongle2.h"
   #include "ClickButton.h"
   #include "eeprom_init.h"
   #include "meter.h"

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -1,5 +1,5 @@
  #include "Arduino.h"
-#include "open_SX70.h"
+#include "open_sx70.h"
 
 /* 
   Version for Edwin, Meroe, Land, and Sonar-FBW PCBs. Works with TSL237T and TCS3200 sensors.

--- a/WORKING/opensx70_lib/sx70_pcb.cpp
+++ b/WORKING/opensx70_lib/sx70_pcb.cpp
@@ -2,7 +2,7 @@
 //#include <EEPROM.h>
 //#include "Arduino.h"
 #include "sx70_pcb.h"
-#include "open_SX70.h"
+#include "open_sx70.h"
 #include "meter.h"
 
 //For SONAR PCB

--- a/WORKING/opensx70_lib/udongle2.cpp
+++ b/WORKING/opensx70_lib/udongle2.cpp
@@ -1,5 +1,5 @@
 #include "DS2408.h"
-#include "uDongle2.h"
+#include "udongle2.h"
 #include "settings.h" // included because of for #if ORIGAMIV1
 
 byte previous_count = 0; //for debouncing


### PR DESCRIPTION
**Problem**

 Project compilation fails in Linux due to .h import strings being different than actual filenames. Non-case-sensitive Operative Systems such as Windows will not experience this issue.

**Solution**

Update import statements to match filenames.
