### PR TITLE
Reduce memory footprint of debug Strings

### DIFF
--- a/WORKING/opensx70_lib/ClickButton.cpp
+++ b/WORKING/opensx70_lib/ClickButton.cpp
@@ -102,7 +102,7 @@ void ClickButton::Update()
       if(clicks != 0){
         changed = true;
       //#if SIMPLEDEBUG
-        Serial.println("Single Click");
+        Serial.println(F("Single Click"));
       //#endif
       }
     }
@@ -119,7 +119,7 @@ void ClickButton::Update()
     if(clicks != 0){
       changed = true;
       //#if SIMPLEDEBUG
-        Serial.println("Long Click");
+        Serial.println(F("Long Click"));
       //#endif
     }
   }

--- a/WORKING/opensx70_lib/DS2408.cpp
+++ b/WORKING/opensx70_lib/DS2408.cpp
@@ -135,7 +135,7 @@ uint8_t  DS2408::find(Devices* devices) {
     Device device;
     while(this->search(device)) {
         if(device[0] == DS2408_FAMILY) {
-            Serial.println("Count DongleFound!!");
+            Serial.println(F("Count DongleFound!!"));
             count++;
         }
     }

--- a/WORKING/opensx70_lib/TCS3200.cpp
+++ b/WORKING/opensx70_lib/TCS3200.cpp
@@ -190,7 +190,7 @@
 
   ISR(TIMER1_OVF_vect){//Timer overflow
     #if LMHELPERDEBUG
-      Serial.print("Timer overflow, Timver value before reset: ");
+      Serial.print(F("Timer overflow, Timver value before reset: "));
       Serial.print(TCNT1);
       TCNT1 = 0;             //set Counter to 0
     #endif
@@ -246,13 +246,13 @@
 
 
     #if LMHELPERDEBUG
-      Serial.print("meter range at Selector: ");
+      Serial.print(F("meter range at Selector: "));
       Serial.print(_selector);
-      Serial.print(" ");
+      Serial.print(F(" "));
       Serial.print(ShutterSpeed[_selector]);
-      Serial.print(" is ");
+      Serial.print(F(" is "));
       Serial.println(meterRange);
-      Serial.print("Predictedmillis: ");
+      Serial.print(F("Predictedmillis: "));
       Serial.println(predictedMillis);
     #endif
 
@@ -263,7 +263,7 @@
         digitalWrite(PIN_LED1, HIGH);
         digitalWrite(PIN_LED2, HIGH);
         #if LMHELPERDEBUG
-          Serial.println("Selector within meter range");
+          Serial.println(F("Selector within meter range"));
         #endif
         return;
       }
@@ -272,7 +272,7 @@
         digitalWrite(PIN_LED1, LOW);
         digitalWrite(PIN_LED2, HIGH);
         #if LMHELPERDEBUG
-          Serial.println("Selector under meter range");
+          Serial.println(F("Selector under meter range"));
         #endif
         return;
       }
@@ -281,7 +281,7 @@
         digitalWrite(PIN_LED1, HIGH);
         digitalWrite(PIN_LED2, LOW);
         #if LMHELPERDEBUG
-          Serial.println("Selector over meter range");
+          Serial.println(F("Selector over meter range"));
         #endif
         return;
       }
@@ -291,7 +291,7 @@
         digitalWrite(PIN_LED1, HIGH);
         digitalWrite(PIN_LED2, LOW);
         #if LMHELPERDEBUG
-          Serial.println("Auto mode low light warning");
+          Serial.println(F("Auto mode low light warning"));
         #endif
       }
       /*

--- a/WORKING/opensx70_lib/TSL235R.cpp
+++ b/WORKING/opensx70_lib/TSL235R.cpp
@@ -146,17 +146,17 @@ void meter_led(byte _selector, byte _type)
     int slot = nearest(PredictedExposure, ShutterSpeed, 11, false);
 
 /*
-    Serial.print ("PredictedExposure: ");
-    Serial.println (PredictedExposure);
+    Serial.print("PredictedExposure: ");
+    Serial.println(PredictedExposure);
 
-    Serial.print ("Estimated SLOT: ");
-    Serial.println (slot);
-    Serial.print ("Actual SLOT: ");
-    Serial.println (_selector);
+    Serial.print("Estimated SLOT: ");
+    Serial.println(slot);
+    Serial.print("Actual SLOT: ");
+    Serial.println(_selector);
 */
     if (_selector < slot)
     {
-      //     Serial.println ("_selector < slot");
+      //     Serial.println("_selector < slot");
       digitalWrite(PIN_LED1, HIGH);
       digitalWrite(PIN_LED2, LOW);
       //digitalWrite(PIN_LED1, LOW);
@@ -166,7 +166,7 @@ void meter_led(byte _selector, byte _type)
     }
     else if (_selector > slot)
     {
-      //     Serial.println ("_selector > slot");
+      //     Serial.println("_selector > slot");
       digitalWrite(PIN_LED2, HIGH);
       digitalWrite(PIN_LED1, LOW);
       //digitalWrite(PIN_LED2, LOW);
@@ -177,7 +177,7 @@ void meter_led(byte _selector, byte _type)
     else if (_selector == slot)
     {
 
-      //   Serial.println ("_selector == slot");
+      //   Serial.println("_selector == slot");
       digitalWrite(PIN_LED2, LOW);
       digitalWrite(PIN_LED1, LOW);
       //digitalWrite(PIN_LED2, HIGH);
@@ -192,7 +192,7 @@ void meter_led(byte _selector, byte _type)
     {
       digitalWrite(PIN_LED2, HIGH);
       digitalWrite(PIN_LED1, HIGH);
-      Serial.println ("LOW LIGHT");
+      Serial.println("LOW LIGHT");
       return;
 
     } else
@@ -236,17 +236,17 @@ int meter_compute(unsigned int _interval) //////////////////////////////////////
       measuring = false;
       PredExp = (((float)myMillis) / ((float) counter)) * (float)outputCompare;
 
-      //Serial.print ("pr mil: ");
-      //Serial.println (previousMillis);
-      //Serial.print ("mil: ");
-      //Serial.println (myMillis);
+      //Serial.print("pr mil: ");
+      //Serial.println(previousMillis);
+      //Serial.print("mil: ");
+      //Serial.println(myMillis);
 
-      //Serial.print ("_interval: ");
-      //Serial.println (_interval);
-      //Serial.print ("counter: ");
-      //Serial.println (counter);
-      //Serial.print ("output compare: ");
-      //Serial.println (outputCompare);
+      //Serial.print("_interval: ");
+      //Serial.println(_interval);
+      //Serial.print("counter: ");
+      //Serial.println(counter);
+      //Serial.print("output compare: ");
+      //Serial.println(outputCompare);
       /*
         Serial.print("                      PredExp: ");
         Serial.println(PredExp);

--- a/WORKING/opensx70_lib/TSL237T.cpp
+++ b/WORKING/opensx70_lib/TSL237T.cpp
@@ -31,7 +31,7 @@
 
   void lmTimer_stop(){ //Stop the Timer1
     #if ADVANCEDEBUG
-      Serial.println("Stop Timer");
+      Serial.println(F("Stop Timer"));
     #endif
     pinMode(PIN_OE, OUTPUT); //Output Enable (OE) pin to enable/disable the Lightsensor
     digitalWrite(PIN_OE, HIGH); //Turn off LM
@@ -77,22 +77,22 @@
     integrationFinished = 1;
     stopIntTime = millis();
     #if LMDEBUG
-      Serial.print("Integration finished CTC ");
-      Serial.print("Counter1 Time: ");
+      Serial.print(F("Integration finished CTC "));
+      Serial.print(F("Counter1 Time: "));
       Serial.println(TCNT1);
-      Serial.print("Exposure Time: ");
+      Serial.print(F("Exposure Time: "));
       Serial.println(stopIntTime - startIntTime);
     #endif
   }
 
   ISR(TIMER1_OVF_vect){//Timer overflow
     //#if LMDEBUG
-      //Serial.print("Timer overflow, Timver value before reset: ");
+      //Serial.print(F("Timer overflow, Timver value before reset: "));
       //Serial.print(TCNT1);
     //#endif
       //TCNT1 = 0;             //set Counter to 0
     //#if LMDEBUG
-      //Serial.print(" Timer overflow, Timver value after reset: ");
+      //Serial.print(F(" Timer overflow, Timver value after reset: "));
       //Serial.println(TCNT1);
     //#endif
     counter = -1;
@@ -112,7 +112,7 @@
     //int _myISO = ReadISO(); //Read ISO from EEPROM
     _myISO = _activeISO;
     #if ADVANCEDEBUG
-      //Serial.print("Meter Compute: Uses this ISO for metering: ");
+      //Serial.print(F("Meter Compute: Uses this ISO for metering: "));
       //Serial.println(_myISO);
     #endif
     static uint32_t previousMillis = 0;
@@ -134,7 +134,7 @@
         if(counter==-1){
             counter = 65536;
             #if LMDEBUG
-              Serial.println("Using Max Value(16bit) on Lightsensor overflow");
+              Serial.println(F("Using Max Value(16bit) on Lightsensor overflow"));
             #endif
         }else{
           counter = TCNT1;
@@ -142,25 +142,25 @@
         PredExp = round((((float)myMillis) / ((float) counter)) * (float)outputCompare);
         measuring = false; //set measuring to false because the current measure is finished
         #if LMDEBUG
-        Serial.print ("pr mil: ");
-        Serial.print (previousMillis);
-        Serial.print (", mil: ");
-        Serial.print (myMillis);
-        Serial.print (", _interval: ");
-        Serial.print (_interval);
-        Serial.print (", counter: ");
-        Serial.print (counter);
-        Serial.print (", output compare: ");
-        Serial.print (outputCompare);
-        Serial.print(", PredExp: ");
+        Serial.print(F("pr mil: "));
+        Serial.print(previousMillis);
+        Serial.print(F(", mil: "));
+        Serial.print(myMillis);
+        Serial.print(F(", _interval: "));
+        Serial.print(_interval);
+        Serial.print(F(", counter: "));
+        Serial.print(counter);
+        Serial.print(F(", output compare: "));
+        Serial.print(outputCompare);
+        Serial.print(F(", PredExp: "));
         Serial.print(PredExp);
-        Serial.print(" PredExp+ShutterConstant: ");
+        Serial.print(F(" PredExp+ShutterConstant: "));
         Serial.println(PredExp+ShutterConstant);
         #endif
         PredExp = PredExp + ShutterConstant;
         if(PredExp>44250){ //bigger then a reliable Value | doesnt know if its needed
           #if LMDEBUG
-          Serial.println("Exception: PredExp > 44250");
+          Serial.println(F("Exception: PredExp > 44250"));
           #endif
           return -2;
         }
@@ -202,19 +202,19 @@
       else if (sorted) return idx;
     }
     if(predExpVal<(shutterSpeeds[0]-6)){ //Let the LM Led light Blue and blink Red or light red and blink blue as a warning for Exposure Values out of possible Shutter Speeds
-      /*Serial.print("predictedValue is smaller than smallest Shutterspeed");
-      Serial.print(" sugested Shutterspeed slot: ");
+      /*Serial.print(F("predictedValue is smaller than smallest Shutterspeed"));
+      Serial.print(F(" sugested Shutterspeed slot: "));
       Serial.print(shutterSpeeds[idx]);
-      Serial.print(" smallest Shutterspeed slot: ");
+      Serial.print(F(" smallest Shutterspeed slot: "));
       Serial.println(shutterSpeeds[0]);
       */
       return -2; //If the predivtedValue is faster than the fastest Shutterspeed with a Margin of one ~Aperture Value
     }
    else if(predExpVal>(shutterSpeeds[slots]+128)){
-      /*Serial.print("predictedValue is bigger than biggest Shutterspeed");
-      Serial.print(" sugested Shutterspeed slot: ");
+      /*Serial.print(F("predictedValue is bigger than biggest Shutterspeed"));
+      Serial.print(F(" sugested Shutterspeed slot: "));
       Serial.print(shutterSpeeds[idx]);
-      Serial.print(" bigest Shutterspeed slot: ");
+      Serial.print(F(" bigest Shutterspeed slot: "));
       Serial.println(shutterSpeeds[slots]);
       */
       return (slots+1); //If the predivted Exposure Value is slower than the slowest Shutterspeed with a Margin of one ~Aperture Value
@@ -226,7 +226,7 @@
     if (_type == 0) //OFF
     {
       #if LMDEBUG
-      Serial.println("LM Helper OFF ");
+      Serial.println(F("LM Helper OFF "));
       #endif
       digitalWrite(PIN_LED1, LOW);
       digitalWrite(PIN_LED2, LOW);
@@ -260,12 +260,12 @@
       int slot = predictSlot(PredictedExposure, ShutterSpeed, 10, false);
       //Shutterspeeds: 17, 20, 23, 25, 30, 35, 45, 55, 68, 102, 166, 
       #if LMHELPERDEBUG
-        Serial.print ("PredictedExposure: ");
-        Serial.print (PredictedExposure);
-        Serial.print (" Estimated SLOT: ");
-        Serial.print (slot);
-        Serial.print (" Actual SLOT: ");
-        Serial.println (_selector);
+        Serial.print(F("PredictedExposure: "));
+        Serial.print(PredictedExposure);
+        Serial.print(F(" Estimated SLOT: "));
+        Serial.print(slot);
+        Serial.print(F(" Actual SLOT: "));
+        Serial.println(_selector);
       #endif
       if(slot == -2){//PredExpValue slower than slowest Shutterspeed
         digitalWrite(PIN_LED2, digitalRead(PIN_LED2) ^ 1); //Blink RED LED
@@ -281,21 +281,21 @@
       {
         if (_selector < slot)
         {
-          //Serial.println ("_selector < slot");
+          //Serial.println(F("_selector < slot"));
           digitalWrite(PIN_LED1, HIGH);
           digitalWrite(PIN_LED2, LOW);
           return;
         }
         else if (_selector > slot)
         {
-          //Serial.println ("_selector > slot");
+          //Serial.println(F("_selector > slot"));
           digitalWrite(PIN_LED1, LOW);
           digitalWrite(PIN_LED2, HIGH);
           return;
         }
         else if (_selector == slot)
         {
-          //Serial.println ("_selector == slot");
+          //Serial.println(F("_selector == slot"));
           digitalWrite(PIN_LED1, LOW);
           digitalWrite(PIN_LED2, LOW);
           return;
@@ -305,15 +305,15 @@
     else if (_type == 1) //Automode
     {
       #if LMHELPERDEBUG
-      Serial.print ("LM Helper PredictedExposure on Auto Mode , PredictedExposure: ");
-      Serial.println (PredictedExposure);
+      Serial.print(F("LM Helper PredictedExposure on Auto Mode , PredictedExposure: "));
+      Serial.println(PredictedExposure);
       #endif
       if (PredictedExposure > 100)
       {
         digitalWrite(PIN_LED1, HIGH);
         digitalWrite(PIN_LED2, HIGH);
         #if LMDEBUG
-          Serial.println ("LOW LIGHT");
+          Serial.println(F("LOW LIGHT"));
         #endif
         return;
       } else

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -69,7 +69,7 @@ int Camera::getGTD() {
 void Camera::S1F_Focus(){
     //int i=0;
     #if FOCUSDEBUG
-      Serial.println ("Focus on");
+      Serial.println("Focus on");
     #endif
     pinMode(PIN_S1F_FBW, OUTPUT);
     digitalWrite(PIN_S1F_FBW, HIGH);
@@ -88,7 +88,7 @@ void Camera::S1F_Focus(){
 
 int Camera::S1F_Focus1(){
     #if FOCUSDEBUG
-      Serial.println ("Focus on");
+      Serial.println("Focus on");
     #endif
     pinMode(PIN_S1F_FBW, OUTPUT);
     digitalWrite(PIN_S1F_FBW, HIGH);
@@ -108,7 +108,7 @@ int Camera::S1F_Focus1(){
 
 void Camera::S1F_Unfocus(){
     #if FOCUSDEBUG
-      Serial.println ("Focus off");
+      Serial.println("Focus off");
     #endif
     pinMode(PIN_S1F_FBW, OUTPUT);
     digitalWrite (PIN_S1F_FBW, LOW);
@@ -148,7 +148,7 @@ void Camera::SelfTimerMUP(){
 
 void Camera::shutterCLOSE(){
   #if BASICDEBUG
-    Serial.println ("shutterCLOSE");
+    Serial.println("shutterCLOSE");
   #endif
   Camera::HighSpeedPWM();
   analogWrite(PIN_SOL1, 255);
@@ -159,7 +159,7 @@ void Camera::shutterCLOSE(){
 
 void Camera::shutterOPEN(){
   #if BASICDEBUG
-    Serial.println ("shutterOPEN");
+    Serial.println("shutterOPEN");
   #endif
   analogWrite (PIN_SOL1, 0);
   return; //Added 26.10.
@@ -174,14 +174,14 @@ void Camera::motorON(){
 
 void Camera::motorOFF(){
   #if BASICDEBUG
-    Serial.println ("motorOFF");
+    Serial.println("motorOFF");
   #endif
   digitalWrite(PIN_MOTOR, LOW);
 }
 
 void Camera::mirrorDOWN(){
   #if BASICDEBUG
-    Serial.println ("mirrorDOWN");
+    Serial.println("mirrorDOWN");
   #endif
   Camera::motorON();
   while (Camera::DebouncedRead(PIN_S5) != LOW){
@@ -195,7 +195,7 @@ void Camera::mirrorDOWN(){
 
 void Camera::mirrorUP(){
   #if BASICDEBUG
-    Serial.println ("mirrorUP");
+    Serial.println("mirrorUP");
   #endif
   motorON ();
 
@@ -210,7 +210,7 @@ void Camera::mirrorUP(){
 
 void Camera::darkslideEJECT(){
   #if SIMPLEDEBUG
-    Serial.println ("darkslideEJECT");
+    Serial.println(F("darkslideEJECT"));
   #endif
   Camera::shutterCLOSE();
   Camera::mirrorUP();
@@ -231,7 +231,7 @@ void Camera::DongleFlashNormal(){
 void DongleFlashF8()
 { 
     #if SIMPLEDEBUG
-    Serial.println ("DONGLE FLASH F8");
+    Serial.println("DONGLE FLASH F8");
     #endif
     //                 byte PictureType = 4;
     //                 CurrentPicture = EEPROM.read(4) ;
@@ -411,11 +411,11 @@ void Camera::Blink (unsigned int interval, int timer, int PinDongle, int PinPCB,
       }
       // set the LED with the ledState of the variable:
       if (type == 1) {
-        //Serial.println ("TYPE 1 - PCB Only");
+        //Serial.println("TYPE 1 - PCB Only");
         digitalWrite (PinPCB, ledState);
       }  
       else if (type == 2) {
-        //Serial.println ("TYPE 2 - PCB and DONGLE");
+        //Serial.println("TYPE 2 - PCB and DONGLE");
         digitalWrite (PinPCB, ledState);
         _dongle->Write_DS2408_PIO (PinDongle, ledState);
       }

--- a/WORKING/opensx70_lib/eeprom_init.cpp
+++ b/WORKING/opensx70_lib/eeprom_init.cpp
@@ -32,10 +32,10 @@ void init_EEPROM(){
   if (initJP[0] != 255 || initJP[1] != 255)
   {
     #if SIMPLEDEBUG
-        Serial.println("Initializing EEPROM....");
-        Serial.print("initJP[0] = ");
+        Serial.println(F("Initializing EEPROM...."));
+        Serial.print(F("initJP[0] = "));
         Serial.print(initJP[0]);
-        Serial.print("initJP[1] = ");
+        Serial.print(F("initJP[1] = "));
         Serial.println(initJP[0]);
     #endif
       EEPROM.update(0, 255);
@@ -47,7 +47,7 @@ void init_EEPROM(){
       //    EEPROM.put(EE_ADD_PIC, currentPicture);
       //    EEPROM.put(EE_ADD_ISO, DEFAULT_ISO);
       #if SIMPLEDEBUG
-        Serial.print("ISO in EEPROM: ");
+        Serial.print(F("ISO in EEPROM: "));
         Serial.println(ReadISO());
       #endif
       return;

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -80,15 +80,15 @@ void setup() {//setup - Inizialize
   currentPicture = ReadPicture();
   #if DEBUG
     Serial.begin(9600);
-    Serial.println("Welcome to openSX70 Version: 28_10_2020_SONAR_FBW-2_TCS3200 GTD and UDONGLE - SM Version + AutoFF");
-    Serial.print("Magic Number: A100=");
+    Serial.println(F("Welcome to openSX70 Version: 28_10_2020_SONAR_FBW-2_TCS3200 GTD and UDONGLE - SM Version + AutoFF"));
+    Serial.print(F("Magic Number: A100="));
     Serial.print(A100);
-    Serial.print("| A600 =");
+    Serial.print(F("| A600 ="));
     Serial.print(A600);
-    Serial.println(" scaling = 100% | filter = clear");
-    Serial.println("State machine core by Zane, Sonar code by Hannes");
-    Serial.println("PCB design and original code by Joaquin");
-    Serial.print("currentPicture stored in EEPROM: ");
+    Serial.println(F(" scaling = 100% | filter = clear"));
+    Serial.println(F("State machine core by Zane, Sonar code by Hannes"));
+    Serial.println(F("PCB design and original code by Joaquin"));
+    Serial.print(F("currentPicture stored in EEPROM: "));
     Serial.println(currentPicture);
   #endif
   
@@ -116,14 +116,14 @@ void setup() {//setup - Inizialize
   {
     openSX70.mirrorDOWN();
     #if SIMPLEDEBUG
-      Serial.println ("Initialize: mirrorDOWN");
+      Serial.println(F("Initialize: mirrorDOWN"));
     #endif
   }
 
   #if SIMPLEDEBUG
-    Serial.print("Inizialized: ");
+    Serial.print(F("Inizialized: "));
     Serial.println(inizialized);
-    Serial.print("currentPicture: ");
+    Serial.print(F("currentPicture: "));
     Serial.println(currentPicture);
   #endif
 }
@@ -161,8 +161,8 @@ camera_state do_state_darkslide (void) {
         myDongle.dongleLed(GREEN, LOW); //switching off green uDongle LED
       }
       #if SIMPLEDEBUG
-        Serial.println("STATE1: EJECT DARK SLIDE");
-        Serial.print("currentPicture on Darkslide eject: ");
+        Serial.println(F("STATE1: EJECT DARK SLIDE"));
+        Serial.print(F("currentPicture on Darkslide eject: "));
         Serial.println(currentPicture);
       #endif
     }
@@ -172,21 +172,21 @@ camera_state do_state_darkslide (void) {
       delay(100);
       BlinkISO();
       #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE");
+        Serial.println(F("TRANSITION TO STATE_DONGLE FROM STATE_DARKSLIDE"));
       #endif
     }
     else if ((selector == 100) && (myDongle.checkDongle() == 0)){
       result = STATE_FLASHBAR;
 
       #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE");
+        Serial.println(F("TRANSITION TO STATE_FLASHBAR FROM STATE_DARKSLIDE"));
       #endif
     }
     else{
       result = STATE_NODONGLE;
 
       #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE");
+        Serial.println(F("TRANSITION TO STATE_NODONGLE FROM STATE_DARKSLIDE"));
       #endif
     }
   #if SHUTTERDARKSLIDE
@@ -225,7 +225,7 @@ camera_state do_state_noDongle (void){
   //Checks for dongle or flashbar insertion
   if (myDongle.checkDongle() > 0){
     #if STATEDEBUG
-      Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_NODONGLE");
+      Serial.println(F("TRANSITION TO STATE_DONGLE FROM STATE_NODONGLE"));
     #endif
     result = STATE_DONGLE;
     //myDongle.initDS2408();
@@ -233,14 +233,14 @@ camera_state do_state_noDongle (void){
       saveISOChange();
     }
     else if(myDongle.selector()<=13){ //Dont blink on AUTOMODE
-      //Serial.println("Transition from no dongle to dongle");
+      //Serial.println(F("Transition from no dongle to dongle"));
       BlinkISO();
     }
   }
   else if ((selector == 100) && (myDongle.checkDongle() == 0)){
     result = STATE_FLASHBAR;
     #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_FLASHBAR FROM STATE_NODONGLE");
+        Serial.println(F("TRANSITION TO STATE_FLASHBAR FROM STATE_NODONGLE"));
     #endif
   }
   return result;
@@ -304,7 +304,7 @@ camera_state do_state_dongle (void){
   if (myDongle.checkDongle() == 0){
     result = STATE_NODONGLE;
     #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_DONGLE");
+        Serial.println(F("TRANSITION TO STATE_NODONGLE FROM STATE_DONGLE"));
     #endif
   } 
   // Multiple Exposure switch flipped
@@ -313,7 +313,7 @@ camera_state do_state_dongle (void){
     multipleExposureMode = true;
     mEXPFirstRun = true;
     #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_MULTI_EXP FROM STATE_DONGLE");
+        Serial.println(F("TRANSITION TO STATE_MULTI_EXP FROM STATE_DONGLE"));
     #endif
   }
 
@@ -343,7 +343,7 @@ camera_state do_state_flashBar (void){
   if ((selector == 200) && (myDongle.checkDongle() == 0)){
     result = STATE_NODONGLE;
     #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_NODONGLE FROM STATE_FLASHBAR");
+        Serial.println(F("TRANSITION TO STATE_NODONGLE FROM STATE_FLASHBAR"));
     #endif
   } 
   return result;
@@ -421,7 +421,7 @@ camera_state do_state_multi_exp (void){
       result = STATE_DONGLE;
 
       #if STATEDEBUG
-        Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_MULTI_EXP");
+        Serial.println(F("TRANSITION TO STATE_DONGLE FROM STATE_MULTI_EXP"));
       #endif
     }
     sw_S1.Reset();
@@ -431,7 +431,7 @@ camera_state do_state_multi_exp (void){
     result = STATE_DONGLE;
     multipleExposureMode = false;
     #if STATEDEBUG
-      Serial.println("TRANSITION TO STATE_DONGLE FROM STATE_MULTI_EXP");
+      Serial.println(F("TRANSITION TO STATE_DONGLE FROM STATE_MULTI_EXP"));
     #endif
   }
   return result;
@@ -439,17 +439,17 @@ camera_state do_state_multi_exp (void){
 
 #if SONAR
 void printReadings() {
-  //Serial.print("GTD: ");
+  //Serial.print(F("GTD: "));
   //Serial.print(openSX70.getGTD());
-  Serial.print("Is Focused: ");
+  Serial.print(F("Is Focused: "));
   Serial.print(isFocused);
-  Serial.print(" | GTD: ");
+  Serial.print(F(" | GTD: "));
   Serial.print(analogRead(PIN_GTD));
-  Serial.print(" | S1F: ");
+  Serial.print(F(" | S1F: "));
   Serial.print(digitalRead(PIN_S1F));
-  Serial.print(" | FT: ");
+  Serial.print(F(" | FT: "));
   Serial.print(analogRead(PIN_FT));
-  Serial.print(" | FF: ");
+  Serial.print(F(" | FF: "));
   Serial.println(digitalRead(PIN_FF));
   return;
 }
@@ -498,7 +498,7 @@ void DongleInserted() { //Dongle is pressend LOOP
   #if SONAR
     if (digitalRead(PIN_S1F) != S1Logic) { //Dont run DongleInserted Function on S1F pressed
   #endif
-      { //Serial.println("S1F HIGH");
+      { //Serial.println(F("S1F HIGH"));
         //selector = myDongle.selector();
         switch1 = myDongle.switch1();
         switch2 = myDongle.switch2();
@@ -508,15 +508,15 @@ void DongleInserted() { //Dongle is pressend LOOP
         if ((selector != prev_selector)) //Update Dongle changes
         {
           #if ADVANCEDEBUG
-            Serial.print ("DONGLE Mode:  ");
-            Serial.print ("Selector: ");
-            Serial.print (selector);
-            Serial.print (" Switch1: ");
-            Serial.print (switch1);
-            Serial.print (" Switch2: ");
-            Serial.print (switch2);
-            Serial.print (" speed: ");
-            Serial.println (ShutterSpeed[selector]);
+            Serial.print(F("DONGLE Mode:  "));
+            Serial.print(F("Selector: "));
+            Serial.print(selector);
+            Serial.print(F(" Switch1: "));
+            Serial.print(switch1);
+            Serial.print(F(" Switch2: "));
+            Serial.print(switch2);
+            Serial.print(F(" speed: "));
+            Serial.println(ShutterSpeed[selector]);
           #endif
           blinkAutomode();
           //blinkSpecialmode(); //B and T Mode Selector LED Blink
@@ -541,7 +541,7 @@ void lmEnable(){
           delay(100);
           digitalWrite(PIN_LED2, LOW);
           #if SIMPLEDEBUG
-            Serial.println("Lightmeter is on");
+            Serial.println(F("Lightmeter is on"));
           #endif
         }
       }
@@ -556,7 +556,7 @@ void lmEnable(){
           delay(100);
           digitalWrite(PIN_LED1, LOW);
         #if SIMPLEDEBUG
-          Serial.println("Lightmeter is off");
+          Serial.println(F("Lightmeter is off"));
         #endif
         }
       }
@@ -568,7 +568,7 @@ void BlinkISO() { //read the default ISO and blink once for SX70 and twice for 6
   switch2 = myDongle.switch2();
   if((switch2 != 1) || (switch1 != 1)){ //Not Save ISO //Changed to OR 01.06.2020
       #if SIMPLEDEBUG
-        Serial.println("Blink for the saved ISO setting on Dongle insertion.");
+        Serial.println(F("Blink for the saved ISO setting on Dongle insertion."));
       #endif
       //blinkAutomode();
       savedISO = ReadISO();
@@ -583,13 +583,13 @@ void BlinkISO() { //read the default ISO and blink once for SX70 and twice for 6
       }
       else{
       #if SIMPLEDEBUG
-        Serial.println("No ISO Selected");
+        Serial.println(F("No ISO Selected"));
         myDongle.simpleBlink(5, RED);
       #endif
       }
       #if SIMPLEDEBUG
-          Serial.print ("EEPROM READ ISO: ");
-          Serial.println (savedISO);
+          Serial.print(F("EEPROM READ ISO: "));
+          Serial.println(savedISO);
       #endif
       prevDongle = nowDongle;
       checkFilmCount();
@@ -603,14 +603,14 @@ void blinkAutomode(){
     if(ShutterSpeed[selector]== AUTO600){
       myDongle.simpleBlink(2, GREEN);
       #if SIMPLEDEBUG
-        Serial.print("blinkAutomode() - Blink 2 times Green on Auto600 selected: ");
+        Serial.print(F("blinkAutomode() - Blink 2 times Green on Auto600 selected: "));
         Serial.println(ShutterSpeed[selector]);
       #endif
       //return;
     }else if(ShutterSpeed[selector]== AUTO100){
       myDongle.simpleBlink(1, GREEN);
       #if SIMPLEDEBUG
-        Serial.print("blinkAutomode() - Blink 1 times Green on Auto100 selected: ");
+        Serial.print(F("blinkAutomode() - Blink 1 times Green on Auto100 selected: "));
         Serial.println(ShutterSpeed[selector]);
       #endif
       //return;
@@ -636,7 +636,7 @@ void blinkSpecialmode(){
 
 void BlinkISORed() { //read the active ISO and blink once for SX70 and twice for 600 - on ISO change
   #if SIMPLEDEBUG
-      Serial.print("Blink RED on ISO change: ");
+      Serial.print(F("Blink RED on ISO change: "));
   #endif
   turnLedsOff();
   if (activeISO == ISO_SX70){
@@ -646,8 +646,8 @@ void BlinkISORed() { //read the active ISO and blink once for SX70 and twice for
     myDongle.simpleBlink(2, RED);
   }
   #if SIMPLEDEBUG
-      Serial.print ("active ISO: ");
-      Serial.println (activeISO);
+      Serial.print(F("active ISO: "));
+      Serial.println(activeISO);
   #endif
   checkFilmCount();
   //return;
@@ -707,8 +707,8 @@ void switch2Function(int mode) {
 void checkFilmCount(){
   if ((currentPicture == 8) || (currentPicture == 9)){
       #if SIMPLEDEBUG
-        Serial.print("Two Frames left!");
-        Serial.print(", currentPicture on Two Frames left: ");
+        Serial.print(F("Two Frames left!"));
+        Serial.print(F(", currentPicture on Two Frames left: "));
         Serial.println(currentPicture);
       #endif
       //myDongle.simpleBlink(2, RED);
@@ -718,8 +718,8 @@ void checkFilmCount(){
   }
   else if(currentPicture == 10){ 
     #if SIMPLEDEBUG
-      Serial.print("Ten Frames shot!");
-      Serial.print(", currentPicture: ");
+      Serial.print(F("Ten Frames shot!"));
+      Serial.print(F(", currentPicture: "));
       Serial.println(currentPicture);
     #endif
     myDongle.dongleLed(GREEN, LOW);
@@ -738,12 +738,12 @@ void ispackEmpty(){ //This is doing nothing right now
     if (firstRun==0){ //Run only one time when Switch S9 change to HIGH
       firstRun++;
       if  (nowDongle != 0) {
-        //Serial.println("STATE2: Set LED RED to High");
+        //Serial.println(F("STATE2: Set LED RED to High"));
         //myDongle.dongleLed(RED, HIGH);
       }
       #if SIMPLEDEBUG
-          Serial.print("STATE2: PACK IS EMPTY - S9 Closed");
-          Serial.print(", Current Picture on Empty Pack: ");
+          Serial.print(F("STATE2: PACK IS EMPTY - S9 Closed"));
+          Serial.print(F(", Current Picture on Empty Pack: "));
           Serial.println(currentPicture);
       #endif
     }
@@ -798,12 +798,12 @@ void saveISOChange() {
   }
   if (savedISO != _selectedISO) { //Check if new ISO is diffrent to the ISO saved in EEPROM
     #if SIMPLEDEBUG
-      Serial.print("SaveISOChange() Function: ");
-      Serial.print("ISO has changed, previos saved ISO (from EEPROM): ");
+      Serial.print(F("SaveISOChange() Function: "));
+      Serial.print(F("ISO has changed, previos saved ISO (from EEPROM): "));
       Serial.println(savedISO);
-      Serial.print("Saving new selected ISO ");
+      Serial.print(F("Saving new selected ISO "));
       Serial.print(_selectedISO);
-      Serial.println(" to the EEPROM");
+      Serial.println(F(" to the EEPROM"));
     #endif
     activeISO = _selectedISO; //Save selectedISO to volatile Variable activeISO
     WriteISO(_selectedISO); //Write ISO to EEPROM
@@ -812,8 +812,8 @@ void saveISOChange() {
   }
   else{
     #if SIMPLEDEBUG
-      Serial.print("SaveISOChange() Function: ");
-      Serial.println("savedISO is equal to selected ISO, dont save!");
+      Serial.print(F("SaveISOChange() Function: "));
+      Serial.println(F("savedISO is equal to selected ISO, dont save!"));
     #endif
     activeISO = _selectedISO;
     BlinkISORed(); //Blink ISO Red

--- a/WORKING/opensx70_lib/udongle2.cpp
+++ b/WORKING/opensx70_lib/udongle2.cpp
@@ -24,7 +24,7 @@ void uDongle::initDS2408() //INTITIALIZE DS2408
   _ds->reset();
   previous_count = selector(); //For Debouncing
   #if ROTARYDEBUG
-  Serial.println("previous count on init:");
+  Serial.println(F("previous count on init:"));
   Serial.println(previous_count);
   #endif
   // THIS IS FUNDAMENTAL
@@ -46,18 +46,18 @@ byte uDongle::Read_DS2408_PIO(int slot)
   // Slot = 1 S1          //Return switch 1 on or off
   // Slot = 2 S2         //Return switch 2 on or off
   byte _Selector = B0000;
-  //Serial.print ("readDevice = ");
-  //Serial.println (readDevice, HEX);
+  //Serial.print("readDevice = ");
+  //Serial.println(readDevice, HEX);
   pinMode(_Pin, INPUT_PULLUP); //changed from INPUT_PULLUP 27_04
   if (digitalRead(_Pin) == LOW)   //////////////////////////////////////////////////////////// CASE FLASH
   {
     return 100; // FLASH
-    Serial.println("flash");
+    Serial.println(F("flash"));
   }
   if  ((_device_count == 0) && (digitalRead(_Pin) == HIGH)) ////////////////////////////////////////////////////////////CASE NOTHING CONNECTED
   {  
     return 200; //NOTHING
-    Serial.println("nothing");
+    Serial.println(F("nothing"));
   }
 
   if (slot == 0) 
@@ -233,19 +233,19 @@ byte uDongle::selector()
         delay(800);
         encoder_count = uDongle::Read_DS2408_PIO(0);
         #if ROTARYDEBUG
-          Serial.println("False reading, wait short and reread: Encoder Count: ");
+          Serial.println(F("False reading, wait short and reread: Encoder Count: "));
           Serial.println(encoder_count);
         #endif
         if((encoder_count==(previous_count+1)||encoder_count==(previous_count-1))){
               #if ROTARYDEBUG
-                 Serial.println("Corrected");
+                 Serial.println(F("Corrected"));
               #endif
               previous_count = encoder_count;
               return encoder_count;
         }
         delay(1500);
         encoder_count = uDongle::Read_DS2408_PIO(0);
-        Serial.println("False reading, wait longer and reread");
+        Serial.println(F("False reading, wait longer and reread"));
          previous_count = encoder_count;
        return encoder_count;
       }else if (encoder_count == previous_count + 1 || encoder_count == previous_count - 1){
@@ -257,7 +257,7 @@ byte uDongle::selector()
         return encoder_count;
      }
    else{
-        Serial.println("else handling");
+        Serial.println(F("else handling"));
         return -2;
       }
 }


### PR DESCRIPTION
**Problem**
Debug print statements contain constant strings that are currently being stored in RAM. Enabling one or more Debug modes can easily result in memory allocation issues due tolow memory available for local variables.

**Solution**
Most debug strings can be moved to PROGMEM using the F macro. This will result in such strings being loaded in RAM on-demand and one byte at the time.
 
**Notes**
This commit does not changes all debug strings to PROGMEM. Some strings are kept in RAM to avoid introducing extra  latency in time sensitive operations. In particular, this commit does not changes logging statements related with the exposure itself.


This change reduces by ~50% the memory footprint of global variables when debugging. I tested enabling all the following flags at the same time: DEBUG, SIMPLEDEBUG, ADVANCEDEBUG, BASICDEBUG, LMHELPERDEBUG. Here my results:

Global variables footprint without this commit:
```
Global variables use 2398 bytes (117%) of dynamic memory, leaving -350 bytes for local variables. Maximum is 2048 bytes.
```

Global variables footprint with this commit:

```
Global variables use 1164 bytes (56%) of dynamic memory, leaving 884 bytes for local variables. Maximum is 2048 bytes.
```

