### PR TITLE
Add time limit to MX mode to avoid selenoid damage

### DIFF
--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -62,6 +62,13 @@
   #define EE_ADD_ADD   30    //-> eeAddress Where to write next
   #define EE_ADD_PIC   13    //-> ActualPicture --> Counter from begining
   #define EE_ADD_ISO   20   //-> camera current ISO (dongleless)
+
+  //---------------MULTIPLE EXPOSURES MODE SETTINGS--------------------------
+  #define MULTIPLE_EXPOSURES_TIMEOUT_ENABLED 1 // 1 -> MX mode will finish after timeout. 0 -> No time limit for MX mode.
+  #define MULTIPLE_EXPOSURES_TIMEOUT 120000 // Max time that MX mode can run for after the first exposure (in milliseconds)
+  //---------------END MULTIPLE EXPOSURES MODE SETTINGS----------------------
+
+  //---------------METER SETTINGS--------------------------------------------
   //---------------OPTION REGARDING SELECTOR WHEEL---------------------------
   //enum positions_t {POST = -100, POSB, AUTO600, AUTO100 };//ANALOGUEWORKS
   enum positions_t {POST = -100, POSB, AUTO600, AUTO100};//ANALOGUEWORKS AUTO 600BW


### PR DESCRIPTION
**Problem:**
Multiple exposures mode allows users to expose selenoid1 for indefinite amount of time. This could result in solenoid damage.

**Solution:**
Limit the amount of time that selenoid1 can be engaged by adding a timeout to MX mode.

**Notes:**
Current timeout set to 2 minutes. This can be adjusted in _settings.h_.