### PR TITLE
New flash capture changes

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -755,6 +755,7 @@ void Camera::ShutterB()
     
   }
   Camera::FastFlash();
+  delay(Flash_Capture_Delay);   //Capture Flash 
 
   ExposureFinish();
   return; //Added 26.10.
@@ -805,6 +806,7 @@ void Camera::ShutterT(){
     //do nothing
   }
   Camera::FastFlash();
+  delay(Flash_Capture_Delay);   //Capture Flash 
 
   #if APERTURE_PRIORITY
     analogWrite(PIN_SOL2, 0);

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -519,7 +519,7 @@ void Camera::AutoExposure(int _myISO){
     Serial.print(", current Picture: ");
     Serial.println(currentPicture);
   #endif
-  lmTimer_stop()
+  lmTimer_stop();
   #if LMDEBUG
   Serial.print(F("AE setting meter to : "));
   Serial.println(_myISO);
@@ -548,7 +548,8 @@ void Camera::AutoExposure(int _myISO){
   #if LMDEBUG
   Serial.print(F("METER_UPDATE status : "));
   Serial.println(meter_update());
-
+  #endif
+  
   meter_init();
   meter_integrate();
   Camera::shutterOPEN();

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -363,6 +363,7 @@ void Camera::Blink (unsigned int interval, int timer, int PinDongle, int PinPCB,
 
 
 void Camera::ManualExposure(){
+  uint32_t initialMillis;
   //changed sonar compile check
   #if SONAR
   Camera::ExposureStart();
@@ -408,7 +409,7 @@ void Camera::ManualExposure(){
     #endif
 
     Camera::shutterOPEN();
-    uint32_t initialMillis = millis();
+    initialMillis = millis();
     while (millis() < (initialMillis + ShutterSpeedDelay)){
       //Take the Picture
     }
@@ -432,7 +433,7 @@ void Camera::ManualExposure(){
     #endif
 
     Camera::shutterOPEN();
-    uint32_t initialMillis = millis();
+    initialMillis = millis();
     while (millis() < (initialMillis + ShutterSpeedDelay)){
       //Take the Picture
     }
@@ -451,6 +452,7 @@ void Camera::ManualExposure(){
 }
 
 void Camera::VariableManualExposure(int _myISO){
+  uint32_t initialMillis;
 
   #if SONAR
   Camera::ExposureStart();
@@ -499,7 +501,7 @@ void Camera::VariableManualExposure(int _myISO){
     meter_init();
     meter_integrate();
 
-    uint32_t initialMillis = millis();
+    initialMillis = millis();
     uint32_t maxMillis = initialMillis + ShutterSpeedDelay;
     Camera::shutterOPEN();
     delay(MinShutterSpeedDelay);
@@ -509,7 +511,7 @@ void Camera::VariableManualExposure(int _myISO){
       }
     }
     Camera::FastFlash ();
-    delay(Flash_Capture_Delay)
+    delay(Flash_Capture_Delay);
 
   }
   else{
@@ -533,7 +535,7 @@ void Camera::VariableManualExposure(int _myISO){
     meter_init();
     meter_integrate();
 
-    uint32_t initialMillis = millis();
+    initialMillis = millis();
     uint32_t maxMillis = initialMillis + ShutterSpeedDelay;
     Camera::shutterOPEN();
     delay(MinShutterSpeedDelay);

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -671,13 +671,14 @@ void Camera::AutoExposureFF(int _myISO){
   #if LMDEBUG
     uint32_t shutterOpenTime = millis(); //Shutter Debug
   #endif
-  uint32_t integrationStartTime = millis();
+  
   analogWrite (PIN_SOL2, 130);    //SOL2 Powersaving
   #if FFDEBUG
     Serial.println("SOL2: 130 - Powersave");
   #endif   
   meter_init();
   meter_integrate();
+  uint32_t integrationStartTime = millis();
   Camera::shutterOPEN(); //Power released from SOL1 - 25ms to get Shutter full open
   //Start FlashDelay  
   while (meter_update() == false){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -391,34 +391,53 @@ void Camera::ManualExposure(){
   #endif
   delay (YDelay);
 
-  int ShutterSpeedDelay = ((ShutterSpeed[selector]) + ShutterConstant);
-  if (selector >= SELECTOR_LIMIT_VARIANCE){
-    ShutterSpeedDelay = (ShutterSpeedDelay - flashDelay);
-  }
-  #if ADVANCEDEBUG
-    extern int selector;
-    Serial.print("Manual Exposure Debug: ");
-    Serial.print("ShutterSpeed[");
-    Serial.print(selector);
-    Serial.print("] :");
-    Serial.println(ShutterSpeed[selector]);
-    Serial.print("ShutterConstant:");
-    Serial.println(ShutterConstant);
-    Serial.print("ShutterSpeedDelay:");
-    Serial.println(ShutterSpeedDelay);
-  #endif
-  
-  Camera::shutterOPEN();
-  uint32_t initialMillis = millis();
-  while (millis() <= (initialMillis + ShutterSpeedDelay)){
-    //Take the Picture
-  }
-  if (selector >= 3){
-    #if SIMPLEDEBUG
-        Serial.println("FF - Fill Flash");
+  if (selector >= Dongle_Flash_Limit){
+    int ShutterSpeedDelay = (ShutterSpeed[selector] - Flash_Capture_Delay);
+
+    #if ADVANCEDEBUG
+      Serial.print("Manual Exposure Debug: ");
+      Serial.print("ShutterSpeed[");
+      Serial.print(selector);
+      Serial.print("] :");
+      Serial.println(ShutterSpeed[selector]);
+      Serial.print("ShutterConstant:");
+      Serial.println(ShutterConstant);
+      Serial.print("ShutterSpeedDelay:");
+      Serial.println(ShutterSpeedDelay);
+      Serial.println("Dongle Flash Enabled");
     #endif
+
+    Camera::shutterOPEN();
+    uint32_t initialMillis = millis();
+    while (millis() < (initialMillis + ShutterSpeedDelay)){
+      //Take the Picture
+    }
     Camera::FastFlash ();
+    delay(Flash_Capture_Delay);
   }
+  else{
+    int ShutterSpeedDelay = ShutterSpeed[selector];
+
+    #if ADVANCEDEBUG
+      Serial.print("Manual Exposure Debug: ");
+      Serial.print("ShutterSpeed[");
+      Serial.print(selector);
+      Serial.print("] :");
+      Serial.println(ShutterSpeed[selector]);
+      Serial.print("ShutterConstant:");
+      Serial.println(ShutterConstant);
+      Serial.print("ShutterSpeedDelay:");
+      Serial.println(ShutterSpeedDelay);
+      Serial.println("Dongle Flash Disabled");
+    #endif
+
+    Camera::shutterOPEN();
+    uint32_t initialMillis = millis();
+    while (millis() < (initialMillis + ShutterSpeedDelay)){
+      //Take the Picture
+    }
+  }
+
   #if LMDEBUG
     uint32_t shutterCloseTime = millis(); //Shutter Debug
   #endif
@@ -460,40 +479,69 @@ void Camera::VariableManualExposure(int _myISO){
   #endif
   delay (YDelay);
 
-  int ShutterSpeedDelay = ShutterSpeed[selector];
-  int MinShutterSpeedDelay = ShutterSpeedDelay -ShutterVariance[selector];
-  
-  #if ADVANCEDEBUG
-    extern int selector;
-    Serial.print("Manual Exposure Debug: ");
-    Serial.print("ShutterSpeed[");
-    Serial.print(selector);
-    Serial.print("] :");
-    Serial.println(ShutterSpeed[selector]);
-    Serial.print("ShutterConstant:");
-    Serial.println(ShutterConstant);
-    Serial.print("ShutterSpeedDelay:");
-    Serial.println(ShutterSpeedDelay);
-  #endif
-
-  meter_set_iso(_myISO);
-  meter_init();
-  meter_integrate();
-
-  uint32_t initialMillis = millis();
-  uint32_t maxMillis = initialMillis + ShutterSpeedDelay;
-  Camera::shutterOPEN();
-  delay(MinShutterSpeedDelay);
-  while(meter_update() == false){
-    if(millis() >= maxMillis){
-      break;
-    }
-  }
-  if (selector >= 3){
-    #if SIMPLEDEBUG
-        Serial.println(F("Sending FF signal to Dongle"));
+  if(selector>= Dongle_Flash_Limit){
+    int ShutterSpeedDelay = ShutterSpeed[selector] - Flash_Capture_Delay;
+    int MinShutterSpeedDelay = ShutterSpeedDelay -ShutterVariance[selector];
+    #if ADVANCEDEBUG
+      extern int selector;
+      Serial.print("Manual Exposure Debug: ");
+      Serial.print("ShutterSpeed[");
+      Serial.print(selector);
+      Serial.print("] :");
+      Serial.println(ShutterSpeed[selector]);
+      Serial.print("ShutterConstant:");
+      Serial.println(ShutterConstant);
+      Serial.print("ShutterSpeedDelay:");
+      Serial.println(ShutterSpeedDelay);
     #endif
+
+    meter_set_iso(_myISO);
+    meter_init();
+    meter_integrate();
+
+    uint32_t initialMillis = millis();
+    uint32_t maxMillis = initialMillis + ShutterSpeedDelay;
+    Camera::shutterOPEN();
+    delay(MinShutterSpeedDelay);
+    while(meter_update() == false){
+      if(millis() >= maxMillis){
+        break;
+      }
+    }
     Camera::FastFlash ();
+    delay(Flash_Capture_Delay)
+
+  }
+  else{
+    int ShutterSpeedDelay = ShutterSpeed[selector];
+    int MinShutterSpeedDelay = ShutterSpeedDelay -ShutterVariance[selector];
+
+    #if ADVANCEDEBUG
+      extern int selector;
+      Serial.print("Manual Exposure Debug: ");
+      Serial.print("ShutterSpeed[");
+      Serial.print(selector);
+      Serial.print("] :");
+      Serial.println(ShutterSpeed[selector]);
+      Serial.print("ShutterConstant:");
+      Serial.println(ShutterConstant);
+      Serial.print("ShutterSpeedDelay:");
+      Serial.println(ShutterSpeedDelay);
+    #endif
+
+    meter_set_iso(_myISO);
+    meter_init();
+    meter_integrate();
+
+    uint32_t initialMillis = millis();
+    uint32_t maxMillis = initialMillis + ShutterSpeedDelay;
+    Camera::shutterOPEN();
+    delay(MinShutterSpeedDelay);
+    while(meter_update() == false){
+      if(millis() >= maxMillis){
+        break;
+      }
+    }
   }
 
   #if LMDEBUG

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -677,19 +677,12 @@ void Camera::AutoExposureFF(int _myISO){
   uint32_t integrationStartTime = millis();
   Camera::shutterOPEN(); //Power released from SOL1 - 25ms to get Shutter full open
   //Start FlashDelay 
-  #if Flashbar_Change
-    while ((meter_update() == false) && ((millis() - integrationStartTime) <= Flash_Min_Time)){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO
-      if((millis() - integrationStartTime) >= Flash_Max_Time){ //Flash can occure anytime of the Flash Delay 56+-7ms depending on scene brightness
-        break;
-      }  
-    }
-  #else
-    while (meter_update() == false){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO
-      if((millis() - integrationStartTime) >= 56){ //Flash can occure anytime of the Flash Delay 56+-7ms depending on scene brightness
-        break;
-      }  
-    }
-  #endif
+  while ((meter_update() == false) && ((millis() - integrationStartTime) <= Flash_Min_Time)){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO
+    if((millis() - integrationStartTime) >= Flash_Max_Time){ //Flash can occure anytime of the Flash Delay 56+-7ms depending on scene brightness
+      break;
+    }  
+  }
+
   #if FFDEBUG
     Serial.print(millis()-integrationStartTime);
     Serial.println("ms Flash Delay Time, Flash fired!");

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -618,8 +618,8 @@ void Camera::AutoExposureFF(int _myISO){
   Camera::shutterOPEN(); //Power released from SOL1 - 25ms to get Shutter full open
   //Start FlashDelay 
   #if Flashbar_Change
-    while ((meter_update() == false) && ((millis() - integrationStartTime) <= 47)){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO
-      if((millis() - integrationStartTime) >= 56){ //Flash can occure anytime of the Flash Delay 56+-7ms depending on scene brightness
+    while ((meter_update() == false) && ((millis() - integrationStartTime) <= Flash_Min_Time)){ //Start FlashDelay: Integrate with the 1/3 of the Magicnumber in Automode of selected ISO
+      if((millis() - integrationStartTime) >= Flash_Max_Time){ //Flash can occure anytime of the Flash Delay 56+-7ms depending on scene brightness
         break;
       }  
     }
@@ -635,7 +635,7 @@ void Camera::AutoExposureFF(int _myISO){
     Serial.println("ms Flash Delay Time, Flash fired!");
   #endif
   digitalWrite(PIN_FF, HIGH);  //FireFlash
-  delay(2);   //Capture Flash 
+  delay(Flash_Capture_Delay);   //Capture Flash 
   #if FFDEBUG
     Serial.print((millis() - flashExposureStartTime));
     Serial.println("ms FlashExposure Integrationtime");

--- a/WORKING/opensx70_lib/settings.cpp
+++ b/WORKING/opensx70_lib/settings.cpp
@@ -22,7 +22,7 @@ byte lightmeterHelper = true;
 
 // Added to remove the need to check for selector values prior to picture taking.
 #if FLIP_ORDER
-  int ShutterSpeed[] = {     25,   29,   32,    34,  39,   44,  64,   64,    175,  311, 609, 1109, A600, A100, POST, POSB };
+  int ShutterSpeed[] = {     25,   29,   32,    34,  39,   44,  64,   64,    175,  311, 609, 1109, AUTO600, AUTO100, POST, POSB };
 #else
   int ShutterSpeed[] = {     25,   29,   32,    34,  39,   44,  64,   64,    175,  311, 609, 1109, POST, POSB, AUTO600, AUTO100 };
 #endif

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -2,12 +2,12 @@
   #define settings_h
   #include "Arduino.h"
   //----------------DEBUG OPTIONS----------------------------------------
-  #define DEBUG 1
+  #define DEBUG 0
   #define SIMPLEDEBUG 0     //Debug of opensx70 functions
   #define ADVANCEDEBUG 0    //More detailed view of OpenSX70 functions
   #define BASICDEBUG 0      //Debug of Basic Camera Functions
   #define MXDEBUG 0         //Multiple Exposure Debug
-  #define LMDEBUG 1         //Lightmeter Debug
+  #define LMDEBUG 0         //Lightmeter Debug
   #define LMHELPERDEBUG 0   //Lightmeter Debug
   #define ROTARYDEBUG 0     //Rotaryswitch on Dongle Debug
   #define STATEDEBUG 0      //Debug state transitions
@@ -27,17 +27,17 @@
   #define TSL237T 0                //Edwin
   #define TSL235R 0                //Alpha 2
   //      Board Version
-  #define MEROE_PCB 0
+  #define MEROE_PCB 1
   #define LAND_PCB 0
-  #define SONAR_PCB 1
+  #define SONAR_PCB 0
   #define SONAR_UNI_PCB 0
   #define EDWIN_PCB 0
   #define ALPHA2_PCB 0
   #define ECM_PCB 0
   //      Camera Options
-  #define S1Logic HIGH              //LOW for Alpha shutters and HIGH for Sonar shutters
-  #define ALPHA 0                  //1 if ALPHA camera functions
-  #define SONAR 1                  //1 for Sonar camera functions   
+  #define S1Logic LOW             //LOW for Alpha shutters and HIGH for Sonar shutters
+  #define ALPHA 1                  //1 if ALPHA camera functions
+  #define SONAR 0                  //1 for Sonar camera functions   
   //      Dongle Options 
   #define FLIP_ORDER 0             //1 to set dongle selector order to "a600 a100 T B" rather than "T B a600 a100". This is for older dongle revisions.
   #define UDONGLE 1

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -2,12 +2,12 @@
   #define settings_h
   #include "Arduino.h"
   //----------------DEBUG OPTIONS----------------------------------------
-  #define DEBUG 0
+  #define DEBUG 1
   #define SIMPLEDEBUG 0     //Debug of opensx70 functions
   #define ADVANCEDEBUG 0    //More detailed view of OpenSX70 functions
   #define BASICDEBUG 0      //Debug of Basic Camera Functions
   #define MXDEBUG 0         //Multiple Exposure Debug
-  #define LMDEBUG 0         //Lightmeter Debug
+  #define LMDEBUG 1         //Lightmeter Debug
   #define LMHELPERDEBUG 0   //Lightmeter Debug
   #define ROTARYDEBUG 0     //Rotaryswitch on Dongle Debug
   #define STATEDEBUG 0      //Debug state transitions
@@ -58,7 +58,7 @@
   //----------------ISO VALUES VALUES---------------------------------------
   #define ISO_600 640
   #define ISO_SX70 125
-  #define DEFAULT_ISO ISO_600
+  #define DEFAULT_ISO ISO_SX70
   //---------------END ISO VALUES--------------------------------------------
 
   //---------------MAGIC NUMBERS---------------------------------------------

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -19,6 +19,7 @@
   #define Flash_Capture_Delay 4
   #define Flash_Max_Time 63
   #define Flash_Min_Time 47
+  #define Dongle_Flash_Limit 4
 
   //----------------CAMERA PCB OPTIONS SELECTION-------------------------
   //      Sensor Selection

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -15,11 +15,8 @@
   #define FFDEBUG 0         //AutoexposureFillFlash Debug
 
   //----------------EXPERIMENTAL OPTIONS---------------------------------
-  #define Flashbar_Change 1
-  #define Flash_Capture_Delay 4
-  #define Flash_Max_Time 63
-  #define Flash_Min_Time 47
-  #define Dongle_Flash_Limit 4
+  
+  // NONE CURRENTLY!
 
   //----------------CAMERA PCB OPTIONS SELECTION-------------------------
   //      Sensor Selection
@@ -76,6 +73,14 @@
     #define A600 225
   #endif
   //---------------END MAGIC NUMBERS-----------------------------------------
+
+  //---------------Flashbar and Dongle Flash---------------------------------
+  #define Flashbar_Change 1
+  #define Flash_Capture_Delay 4
+  #define Flash_Max_Time 63
+  #define Flash_Min_Time 47
+  #define Dongle_Flash_Limit 4
+  //---------------End Flash settings----------------------------------------
 
   //---------------Shutter Settings------------------------------------------
   #define SELECTOR_LIMIT_VARIANCE 6

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -15,7 +15,10 @@
   #define FFDEBUG 0         //AutoexposureFillFlash Debug
 
   //----------------EXPERIMENTAL OPTIONS---------------------------------
-  #define Flashbar_Change 0
+  #define Flashbar_Change 1
+  #define Flash_Capture_Delay 4
+  #define Flash_Max_Time 63
+  #define Flash_Min_Time 47
 
   //----------------CAMERA PCB OPTIONS SELECTION-------------------------
   //      Sensor Selection
@@ -23,17 +26,17 @@
   #define TSL237T 0                //Edwin
   #define TSL235R 0                //Alpha 2
   //      Board Version
-  #define MEROE_PCB 1
+  #define MEROE_PCB 0
   #define LAND_PCB 0
-  #define SONAR_PCB 0
+  #define SONAR_PCB 1
   #define SONAR_UNI_PCB 0
   #define EDWIN_PCB 0
   #define ALPHA2_PCB 0
   #define ECM_PCB 0
   //      Camera Options
-  #define S1Logic LOW              //LOW for Alpha shutters and HIGH for Sonar shutters
-  #define ALPHA 1                  //1 if ALPHA camera functions
-  #define SONAR 0                  //1 for Sonar camera functions   
+  #define S1Logic HIGH              //LOW for Alpha shutters and HIGH for Sonar shutters
+  #define ALPHA 0                  //1 if ALPHA camera functions
+  #define SONAR 1                  //1 for Sonar camera functions   
   //      Dongle Options 
   #define FLIP_ORDER 0             //1 to set dongle selector order to "a600 a100 T B" rather than "T B a600 a100". This is for older dongle revisions.
   #define UDONGLE 1
@@ -52,7 +55,7 @@
   #define EJECT_AFTER_DEPRESSING 0 //1 Enables the user to hold the shutter button to prevent photo ejection
   //----------------END CAMERA PCB OPTIONS SELECTION------------------------
 
-  //----------------ISO VALUES----------------------------------------------
+  //----------------ISO VALUES VALUES---------------------------------------
   #define ISO_600 640
   #define ISO_SX70 125
   #define DEFAULT_ISO ISO_600
@@ -60,7 +63,7 @@
 
   //---------------MAGIC NUMBERS---------------------------------------------
   #if TCS3200
-    #define A100 400
+    #define A100 450
     #define A600 150
   #endif
   #if TSL237T


### PR DESCRIPTION
Changing how flash works just a bit. Overall flash will now fire earlier in the exposure and will have more time to be caught by the shutter being open at the maximum. Should prevent flash from not being caught at higher solenoid speeds.

Flashbars now have a configurable minimum and maximum flash exposure time in the settings. Flash minimum was previously not implemented per the spec of the Alpha fill flash. This has been fixed in this version of the code. 
