### PR TITLE
bugfixes and redundancy removal

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -499,11 +499,10 @@ void Camera::AutoExposure(int _myISO){
   output_serial(F("METER_UPDATE status : "));
   output_line_serial(String(meter_update()));
   #endif
-  
-  // TODO - Move this to top level, does not need to run per exposure
 
-  meter_init();
+  meter_set_iso(_myISO);
   meter_reset();
+
   Camera::shutterOPEN();
   #if LMDEBUG
     uint32_t shutterOpenTime = millis(); //Shutter Debug
@@ -527,9 +526,6 @@ void Camera::AutoExposure(int _myISO){
 // TODO Explore this one a bit. It may be possible to remove the hard coded timing
 // and move purely to a meter-based approach. Would be faster and more consistent.
 void Camera::AutoExposureFF(int _myISO){
-  Camera::shutterCLOSE();
-  Camera::mirrorUP();   
-
   Camera::sol2Engage();
   delay(YDelay);           //AT Yd and POWERS OFF AT FF
 

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -390,36 +390,13 @@ void Camera::ManualExposure(int _myISO, uint8_t selector){
 void Camera::VariableManualExposure(int _myISO, uint8_t selector){
   uint32_t initialMillis;
 
-  pinMode(PIN_S3, INPUT_PULLUP); // GND
-  while (digitalRead(PIN_S3) != HIGH){            //waiting for S3 to OPEN
-     #if BASICDEBUG
-     output_line_serial("waiting for S3 to OPEN");
-     #endif
-  }
-  #if APERTURE_PRIORITY
-    AperturePriority();
-  #endif
   delay (YDelay);
 
-  if(selector>= Dongle_Flash_Limit){
+  if(selector >= Dongle_Flash_Limit){
     int ShutterSpeedDelay = ShutterSpeed[selector] - Flash_Capture_Delay;
     int MinShutterSpeedDelay = ShutterSpeedDelay -ShutterVariance[selector];
-    #if ADVANCEDEBUG
-      output_serial("Manual Exposure Debug: ");
-      output_serial("ShutterSpeed[");
-      output_serial(String(selector));
-      output_serial("] :");
-      output_line_serial(String(ShutterSpeed[selector]));
-      output_serial("ShutterConstant:");
-      output_line_serial(String(ShutterConstant));
-      output_serial("ShutterSpeedDelay:");
-      output_line_serial(String(ShutterSpeedDelay));
-    #endif
 
     meter_set_iso(_myISO);
-    // TODO - Move this to top level, does not need to run per exposure
-
-    meter_init();
     meter_reset();
 
     initialMillis = millis();

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -530,7 +530,7 @@ void Camera::AutoExposureFF(int _myISO){
   Camera::shutterCLOSE();
   Camera::mirrorUP();   
 
-  Camera:sol2Engage();
+  Camera::sol2Engage();
   delay(YDelay);           //AT Yd and POWERS OFF AT FF
 
   uint16_t FD_MN = 0;  //FlashDelay Magicnumber

--- a/WORKING/opensx70_lib/logging.cpp
+++ b/WORKING/opensx70_lib/logging.cpp
@@ -3,30 +3,37 @@
 #include "logging.h"
 
 #ifdef ARDUINO_GENERIC_G030K8TX
+#if DEBUG
 HardwareSerial STMUART(USART_RX, USART_TX);
+#endif
 #endif
 
 void serial_init(){
+    #if DEBUG
     #ifdef ARDUINO_AVR_PRO
         Serial.begin(9600);
     #elif defined ARDUINO_GENERIC_G030K8TX
         STMUART.begin(19200);
     #endif
-
+    #endif
 }
 
 void output_line_serial(String const& input){
+    #if DEBUG
     #ifdef ARDUINO_AVR_PRO
         Serial.println(input);
     #elif defined ARDUINO_GENERIC_G030K8TX
         STMUART.println(input);
     #endif
+    #endif
 }
 
 void output_serial(String const& input){
+    #if DEBUG
     #ifdef ARDUINO_AVR_PRO
         Serial.print(input);
     #elif defined ARDUINO_GENERIC_G030K8TX
         STMUART.print(input);
+    #endif
     #endif
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -90,14 +90,9 @@ void setup() {//setup - Inizialize
 
 /*LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP*/
 void loop() {
-  if ((digitalRead(PIN_S1F) == HIGH)){
-    preFocus();
-  }
-  else{
-    unfocusing();
-  }
   previous_status = current_status;
   current_status = peripheral.get_peripheral_status();
+  sonarFocus();
   sw_S1.Update();
   state = STATE_MACHINE[state]();
 }
@@ -354,14 +349,11 @@ camera_state do_state_multi_exp (void){
   return result;
 }
 
-void preFocus() {
-  if ((digitalRead(PIN_S1F) == HIGH)) { // S1F pressed
+void sonarFocus() {
+  if ((digitalRead(PIN_S1F) == HIGH)){
     openSX70.S1F_Focus();
   }
-}
-
-void unfocusing(){
-  if ((digitalRead(PIN_S1F) == LOW)) {
+  else{
     openSX70.S1F_Unfocus();
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -99,7 +99,6 @@ void loop() {
   previous_status = current_status;
   current_status = peripheral.get_peripheral_status();
   sw_S1.Update();
-  //normalOperation();
   state = STATE_MACHINE[state]();
 }
 
@@ -150,7 +149,7 @@ camera_state do_state_darkslide (void) {
   
   savedISO = ReadISO();
   meter_set_iso(savedISO);
-  
+
   return result;
 }
 
@@ -535,38 +534,6 @@ void switch2Function(int mode) {
   #if SIMPLEDEBUG
     output_line_serial(F("Self Timer End"));
   #endif
-}
-
-void normalOperation(){
-  if (digitalRead(PIN_S8) == LOW && digitalRead(PIN_S9) == LOW){
-      //WHAT TO DO WHEN POWER-UP:
-      //  S8     S9
-      // closed  open  --> EJECT DARKSLIDE (DEFAULT)
-      // open  closed --> FILM REACH 0 (NO FLASH)
-      // open   open  --> NORMAL OPERATION 10 TO 1
-      // ///////////////////////////////////PICTURE TAKING OPERATION//////////////////////////////////////////////////
-      //    FOUR CASES:
-      //   *  CASE 1 NORMAL OPERATION: FULL CYCLE
-      //   *  SELECTOR = NORMAL (LOW)
-      //   *  MXSHOTS = 0
-      //   *  PIN_S1 = LOW (RED BUTTON PRESSED)
-      //   *
-      //   *  CASE 2 DOUBLE EXPOSURE FIRST SHOT: MIRROR DOWN AND FIRST PICTURE (CLICK: SHUTTER OPERATION REMAINING CLOSED)
-      //   *  SELECTOR = DOUBLE (HIGH)
-      //   *  MXSHOTS = 0
-      //   *  PIN_S1 = LOW (RED BUTTON PRESSED)
-      //   *
-      //   *  CASE 3 DOUBLE EXPOSURE ULTERIOR MXSHOTS: NO MOTOR OPERATION JUST PICTURE (CLICK: SHUTTER OPERATION REMAINING CLOSED)
-      //   *  SELECTOR = DOUBLE (HIGH)
-      //   *  MXSHOTS >= 1
-      //   *  PIN_S1 = LOW (RED BUTTON PRESSED)
-      //   *
-      //   *  CASE 4 PICTURE EXPULSION AFTER DOUBLE EXPOSURE: MIRROR DOWN AND SHUTTER OPENING (NO PICTURE TAKEN)
-      //   *
-      //   *  SELECTOR = NORMAL (LOW)
-      //   *  MXSHOTS >= 1
-    sw_S1.Update();
-  }
 }
 
 void saveISOChange() {

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -84,6 +84,7 @@ void setup() {//setup - Inizialize
     #endif
   }
   S1ISOSwap();
+  savedISO = ReadISO();
 }
 
 /*LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP*/
@@ -139,10 +140,6 @@ camera_state do_state_darkslide (void) {
   sw_S1.Reset();
   }
   #endif
-  
-  savedISO = ReadISO();
-  meter_set_iso(savedISO);
-
   return result;
 }
 

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -71,8 +71,7 @@ void setup() {//setup - Inizialize
   mEXPFirstRun = false;
   multipleExposureMode = false;
 
-  savedISO = ReadISO();
-  meter_set_iso(savedISO);
+  
 
   if (digitalRead(PIN_S5) != LOW)
   {
@@ -148,6 +147,9 @@ camera_state do_state_darkslide (void) {
   sw_S1.Reset();
   }
   #endif
+  
+  savedISO = ReadISO();
+  meter_set_iso(savedISO);
   
   return result;
 }
@@ -654,6 +656,7 @@ void S1ISOSwap(){
     activeISO = _selectedISO;
     WriteISO(_selectedISO);
     savedISO = ReadISO();
+    meter_set_iso(activeISO);
     while(digitalRead(PIN_S1) == HIGH){
       //wait....
     }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -82,10 +82,7 @@ void setup() {//setup - Inizialize
     output_line_serial(F("Initialize: mirrorDOWN"));
     #endif
   }
-
-  #if DONGLE_FREE_ISO_CHANGE
   S1ISOSwap();
-  #endif
 }
 
 /*LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP*/
@@ -573,7 +570,6 @@ void LightMeterHelper(byte ExposureType){
   }
 }
 
-#if DONGLE_FREE_ISO_CHANGE
 void viewfinderBlink(uint8_t LEDPIN){
   digitalWrite(LEDPIN, HIGH);
   delay(100);
@@ -622,4 +618,3 @@ void S1ISOSwap(){
   }
   sw_S1.Reset();
 }
-#endif

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -370,7 +370,6 @@ void turnLedsOff(){ //TODO :move to camerafunction
 
 void DongleInserted() { //Dongle is pressend LOOP
   if (digitalRead(PIN_S1) != S1Logic) { //Dont run DongleInserted Function on S1T pressed
-    lmEnable(); //added 26.10.
     if ((current_status.selector != previous_status.selector)){
       #if ADVANCEDEBUG
         output_serial(F("DONGLE Mode:  "));
@@ -385,37 +384,6 @@ void DongleInserted() { //Dongle is pressend LOOP
       #endif
       // TODO Move this into state transition
       blinkAutomode();
-    }
-  }
-}
-
-void lmEnable(){
-  if(current_status.switch1 && current_status.switch2){
-    if(current_status.selector == 12){ //POST
-      if (openSX70.getLIGHTMETER_HELPER() == false) {
-        openSX70.setLIGHTMETER_HELPER(true);
-        turnLedsOff();
-        digitalWrite(PIN_LED2, HIGH); //Blink Blue -- LMH On
-        peripheral.simpleBlink(1, GREEN);
-        delay(100);
-        digitalWrite(PIN_LED2, LOW);
-        #if SIMPLEDEBUG
-          output_line_serial(F("Lightmeter is on"));
-        #endif
-      }
-    }
-    else if(current_status.selector == 13){ //POSB
-      if (openSX70.getLIGHTMETER_HELPER() == true) {
-        openSX70.setLIGHTMETER_HELPER(false);
-        turnLedsOff();
-        digitalWrite(PIN_LED1, HIGH); //Blink RED -- LMH Off
-        peripheral.simpleBlink(1, RED);
-        delay(100);
-        digitalWrite(PIN_LED1, LOW);
-      #if SIMPLEDEBUG
-        output_line_serial(F("Lightmeter is off"));
-      #endif
-      }
     }
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -481,7 +481,7 @@ void LightMeterHelper(byte ExposureType){
 }
 
 void viewfinderBlink(uint8_t LEDPIN){
-  for(i=0; i<2; i++){
+  for(uint8_t i=0; i<2; i++){
     digitalWrite(LEDPIN, HIGH);
     delay(100);
     digitalWrite(LEDPIN, LOW);

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -11,7 +11,6 @@ status current_status;
 status previous_status;
 
 int savedISO;
-int activeISO;
 
 bool mEXPFirstRun;
 bool multipleExposureMode;
@@ -534,16 +533,12 @@ void BlinkISORed() { //read the active ISO and blink once for SX70 and twice for
       output_serial(F("Blinking ISO change"));
   #endif
   turnLedsOff();
-  if (activeISO == ISO_SX70){
+  if (savedISO == ISO_SX70){
     peripheral.simpleBlink(1, RED);
   }
-  else if (activeISO == ISO_600){
+  else if (savedISO == ISO_600){
     peripheral.simpleBlink(2, RED);
   }
-  #if SIMPLEDEBUG
-    output_serial(F("active ISO: "));
-    output_line_serial(activeISO);
-  #endif
 }
 
 void S1ISOSwap(){
@@ -601,7 +596,7 @@ void dongleISOSwap() {
     BlinkISORed();
   }
   else{
-    activeISO = _selectedISO;
+    savedISO = _selectedISO;
     BlinkISORed(); //Blink ISO Red
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -173,7 +173,7 @@ camera_state do_state_noDongle (void){
     result = STATE_DONGLE;
     savedISO = ReadISO();
     if(((current_status.switch1 == 1) && (current_status.switch2 == 1))){
-      saveISOChange();
+      dongleISOSwap();
     }
     else if(current_status.selector<=13){ //Dont blink on AUTOMODE
       BlinkISO();
@@ -525,7 +525,7 @@ void switch2Function(int mode) {
   #endif
 }
 
-void saveISOChange() {
+void dongleISOSwap() {
   int _selectedISO;
   savedISO = ReadISO(); //read the savedISO from the EEPROM
   if (((ShutterSpeed[current_status.selector]) == AUTO600)) {
@@ -539,14 +539,6 @@ void saveISOChange() {
     _selectedISO = DEFAULT_ISO;
   }
   if (savedISO != _selectedISO) { //Check if new ISO is diffrent to the ISO saved in EEPROM
-    #if SIMPLEDEBUG
-      output_serial(F("SaveISOChange() Function: "));
-      output_serial(F("ISO has changed, previos saved ISO (from EEPROM): "));
-      output_line_serial(savedISO);
-      output_serial(F("Saving new selected ISO "));
-      output_serial(_selectedISO);
-      output_line_serial(F(" to the EEPROM"));
-    #endif
     activeISO = _selectedISO; //Save selectedISO to volatile Variable activeISO
     WriteISO(_selectedISO); //Write ISO to EEPROM
     savedISO = ReadISO();
@@ -555,10 +547,6 @@ void saveISOChange() {
 
   }
   else{
-    #if SIMPLEDEBUG
-      output_serial(F("SaveISOChange() Function: "));
-      output_line_serial(F("savedISO is equal to selected ISO, dont save!"));
-    #endif
     activeISO = _selectedISO;
     BlinkISORed(); //Blink ISO Red
   }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -71,7 +71,9 @@ void setup() {//setup - Inizialize
   multipleExposureMode = false;
 
   
-
+  // Move some setup stuff into its own init state
+  // Reason for this is to add branching option for making the dark slide eject a standard exposure
+  // (Changing bag pack swap)
   if (digitalRead(PIN_S5) != LOW)
   {
     openSX70.shutterCLOSE();

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -35,7 +35,6 @@
   #define EIGHT_SHOT_PACK 1        //1 Makes all counter-based functions work based on an 8 shot pack rather than 10
   #define LIGHMETER_HELPER 1       //1 Enables viewfinder light meter helper
   #define EJECT_AFTER_DEPRESSING 1 //1 Enables the user to hold the shutter button to prevent photo ejection
-  #define DONGLE_FREE_ISO_CHANGE 1 //1 Enables using the shutter button on startup to swap ISO
   //----------------END CAMERA PCB OPTIONS SELECTION------------------------
 
   //----------------ISO VALUES VALUES---------------------------------------


### PR DESCRIPTION
Shutter button ISO swap was bugged and would not load the new ISO from EEPROM into the global variable that dictates ISO for exposures. Issue has been fixed.

I may transition fully to only read off of the EEPROM/simulated EEPROM. Speed difference is negligible between reading from EEPROM and reading from SRAM. 