### PR TITLE
L3i mode

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -175,14 +175,6 @@ void Camera::mirrorUP(){
   motorOFF ();
 }
 
-void Camera::startMeter(int _myISO){
-  meter_set_iso(_myISO);
-  meter_init();
-  meter_integrate();
-}
-
-
-
 void Camera::darkslideEJECT(){
   #if SIMPLEDEBUG
     output_line_serial(F("darkslideEJECT"));

--- a/WORKING/opensx70_lib/camera_functions.h
+++ b/WORKING/opensx70_lib/camera_functions.h
@@ -16,7 +16,6 @@
       void sol2Disengage();
       void mirrorDOWN();
       void mirrorUP();
-      void startMeter(int _myISO);
       void darkslideEJECT();
       void motorON();
       void motorOFF();

--- a/WORKING/opensx70_lib/meter.h
+++ b/WORKING/opensx70_lib/meter.h
@@ -13,8 +13,6 @@
   extern void meter_set_iso(uint16_t const& iso);
   // compute the time needed for current ligth condition so it can be display as an indication in the viewfinder
   extern int meter_compute(unsigned int _interval);
-  // start an integration cycle for auto exposure
-  extern void meter_integrate();
   // get the update from the sensor. When enough light has reached the film, returns true.
   extern bool meter_update();
   extern void meter_set_iso(uint16_t const& iso);

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -200,11 +200,12 @@ camera_state do_state_dongle (void){
   camera_state result = STATE_DONGLE;
   DongleInserted();
   
-  if(current_status.selector<=11){
-    LightMeterHelper(2); //LMHelper Manual Mode
-  }
-  else if(ShutterSpeed[current_status.selector] == A100 || ShutterSpeed[current_status.selector] == A600){
+
+  if(ShutterSpeed[current_status.selector] == A100 || ShutterSpeed[current_status.selector] == A600){
     LightMeterHelper(1); //LMHelper Auto Mode
+  }
+  else{
+    LightMeterHelper(0);
   }
   
   if ((sw_S1.clicks == -1) || (sw_S1.clicks > 0)){

--- a/WORKING/opensx70_lib/settings.cpp
+++ b/WORKING/opensx70_lib/settings.cpp
@@ -22,7 +22,7 @@ byte lightmeterHelper = true;
 
 // Added to remove the need to check for selector values prior to picture taking.
 
-int ShutterSpeed[] = {     25,   29,   32,    34,  39,   44,  64,   64,    175,  311, 609, 1109, POST, POSB, AUTO600, AUTO100 };
+int ShutterSpeed[] = {     25,   28,   32,    36,  40,   44,  64,   120,    175,  311, 609, 1109, POST, POSB, AUTO600, AUTO100 };
 
 //int ShutterSpeed[] = { 2000, 1000,  500,   250, 125,   60,  30,   15,      8,    4,   2,    1, T, B, AUTO600, AUTO100 };
 //                          0     1     2      3    4     5    6     7       8     9    10   11
@@ -38,15 +38,15 @@ int ShutterSpeed[] = {     25,   29,   32,    34,  39,   44,  64,   64,    175, 
 int flashDelay = 1; //new flash "system"
   // (These are default if not set, but changeable for convenience)
 
-int ShutterVariance[] = {  15,   10,   8,     6,    6,    6,   6,    6,      10,    20,   40,   40};
+int ShutterVariance[] = {  6,   6,   6,     6,    6,    6,   6,    6,      10,    20,   40,   40};
 //int ShutterSpeed[] = { 2000, 1000,  500,   250,  125,   60,  30,   15,      8,    4,   2,   1
 //                          0     1     2      3    4     5    6     7       8     9    10   11
 
 
-int MinRange[] =       {   10,   20,   24,    28,   33,   38,  44,   50,    121,   200, 551,  1001};
+int MinRange[] =       {   19,   26,   29,    33,   37,   41,  45,   65,     121,   176, 312,  610};
 //int ShutterSpeed[] = { 2000, 1000,  500,   250,  125,   60,  30,   15,      8,    4,   2,   1
-//                          0     1     2      3    4     5    6     7       8     9    10   11
+//                          0     1     2      3    4     5    6     7        8     9    10   11
 
-int MaxRange[] =       {   25,   29,   32,    34,   39,   49,  89,   120,    199,  550, 1000, 1250};
+int MaxRange[] =       {   25,   28,   32,    36,   40,   44,  64,   120,    175,  311, 609, 1109};
 //int ShutterSpeed[] = { 2000, 1000,  500,   250,  125,   60,  30,   15,      8,    4,   2,   1
 //                          0     1     2      3    4     5    6     7       8     9    10   11


### PR DESCRIPTION
Removing light meter LED function (RIP), keeping in L3I simulation.

New meter design is too sensitive at F8 to accurately predict shutter speed timings.