### PR TITLE
Added auto mode timeout

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -437,6 +437,7 @@ void Camera::VariableManualExposure(int _myISO, uint8_t selector){
 }
 
 void Camera::AutoExposure(int _myISO){
+  
   delay(YDelay);
 
   meter_set_iso(_myISO);
@@ -444,7 +445,12 @@ void Camera::AutoExposure(int _myISO){
 
   Camera::shutterOPEN();
 
+  uint32_t timeoutThreshold = millis() + AUTO_TIMEOUT;
   while (meter_update() == false){
+    // timeout if current exposure hits AUTO_TIMEOUT
+    if ((millis() >= timeoutThreshold) ){
+      break;
+    }
   }
 
   Camera::ExposureFinish();

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -62,6 +62,7 @@
   //---------------End Shutter Settings--------------------------------------
 
   //---------------METER SETTINGS--------------------------------------------
+  #define AUTO_TIMEOUT 15000 //Sets the maximum time an auto exposure can take place. Required due to new meter design.
   #define METER_INTERVAL 100 // Sets how long each meter measurement sample is taken in ms
   #define METER_AUTO_WARNING 100 // If predicted ms is over this value, warning LED will shine in auto mode
   #define METER_PREDICTION_OFFSET 20 // in ms. This gets added to the prediction. At f8 I noticed all meter predictions were around 20ms off


### PR DESCRIPTION
Added auto mode timeout. Longer exposures should be done via B or T modes.