### PR TITLE
Manual adjustments

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -81,7 +81,7 @@ void Camera::shutterCLOSE(){
   #ifdef ARDUINO_GENERIC_G030K8TX
     SolenoidPWM->setPWM(1, PIN_SOL1, 62000, 100);
     delay (PowerDownDelay);
-    SolenoidPWM->setPWM(1, PIN_SOL1, 62000, 70);
+    SolenoidPWM->setPWM(1, PIN_SOL1, 62000, 30);
   #endif
 
   return;
@@ -116,7 +116,7 @@ void Camera::sol2LowPower(){
     analogWrite(PIN_SOL2, 130);
   #endif
   #ifdef ARDUINO_GENERIC_G030K8TX
-    SolenoidPWM->setPWM(2, PIN_SOL2, 62000, 70);
+    SolenoidPWM->setPWM(2, PIN_SOL2, 62000, 30);
   #endif
 }
 

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -76,7 +76,7 @@ void Camera::shutterCLOSE(){
   #ifdef ARDUINO_AVR_PRO
     analogWrite(PIN_SOL1, 255);
     delay (PowerDownDelay);
-    analogWrite (PIN_SOL1, 77);
+    analogWrite (PIN_SOL1, 130);
   #endif
   #ifdef ARDUINO_GENERIC_G030K8TX
     SolenoidPWM->setPWM(1, PIN_SOL1, 62000, 100);
@@ -116,7 +116,7 @@ void Camera::sol2LowPower(){
     analogWrite(PIN_SOL2, 77);
   #endif
   #ifdef ARDUINO_GENERIC_G030K8TX
-    SolenoidPWM->setPWM(2, PIN_SOL2, 62000, 30);
+    SolenoidPWM->setPWM(2, PIN_SOL2, 62000, 130);
   #endif
 }
 

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -76,7 +76,7 @@ void Camera::shutterCLOSE(){
   #ifdef ARDUINO_AVR_PRO
     analogWrite(PIN_SOL1, 255);
     delay (PowerDownDelay);
-    analogWrite (PIN_SOL1, PowerDown);
+    analogWrite (PIN_SOL1, 77);
   #endif
   #ifdef ARDUINO_GENERIC_G030K8TX
     SolenoidPWM->setPWM(1, PIN_SOL1, 62000, 100);
@@ -113,7 +113,7 @@ void Camera::sol2Engage(){
 
 void Camera::sol2LowPower(){
   #ifdef ARDUINO_AVR_PRO
-    analogWrite(PIN_SOL2, 130);
+    analogWrite(PIN_SOL2, 77);
   #endif
   #ifdef ARDUINO_GENERIC_G030K8TX
     SolenoidPWM->setPWM(2, PIN_SOL2, 62000, 30);

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -55,7 +55,9 @@ void setup() {//setup - Inizialize
   #endif
 
   io_init();
+  validateISO();
   meter_init();
+  meter_set_iso(savedISO);
 
   peripheral.initDS2408();
   init_EEPROM(); //#writes Default ISO to EEPROM
@@ -84,7 +86,6 @@ void setup() {//setup - Inizialize
     #endif
   }
   S1ISOSwap();
-  validateISO();
 }
 
 /*LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP LOOP*/

--- a/WORKING/opensx70_lib/opensx70_meter.cpp
+++ b/WORKING/opensx70_lib/opensx70_meter.cpp
@@ -58,6 +58,7 @@ int meter_compute(byte _selector,int _activeISO){
     measuring = true;
     meter_reset();
     startMillis = millis();
+    meter_set_iso(_activeISO);
   }
   else{
     endMillis = millis();

--- a/WORKING/opensx70_lib/settings.cpp
+++ b/WORKING/opensx70_lib/settings.cpp
@@ -4,7 +4,7 @@
 int mxshots = 0; //Multiple exposure counter
 const uint8_t YDelay = 120;
 const byte PowerDownDelay = 15; //time it takes to be fully closed
-const byte PowerDown = 130; //max 255 = full power/POWERUP mode
+const byte PowerDown = 77; //max 255 = full power/POWERUP mode
 int FD100 = round(.29*A100);
 int FD600 = round(.29*A600);
 int ShutterConstant = 0; // was 9; Setting this to 0 to remove need for doing math. putting this in the raw speed. - Zane

--- a/WORKING/opensx70_lib/settings.cpp
+++ b/WORKING/opensx70_lib/settings.cpp
@@ -22,7 +22,7 @@ byte lightmeterHelper = true;
 
 // Added to remove the need to check for selector values prior to picture taking.
 //int ShutterSpeed[] = {     23,   26,   30,    36,  40,   44,  64,   120,    175,  275, 525, 1025, POST, POSB, AUTO600, AUTO100 };
-int ShutterSpeed[] = {     23,   24,   25,    27,  31,   38,  56,   90,    148,  273, 523, 1023, POST, POSB, AUTO600, AUTO100 };
+int ShutterSpeed[] = {     22,   24,   25,    27,  31,   38,  56,   90,    148,  273, 523, 1023, POST, POSB, AUTO600, AUTO100 };
 
 //int ShutterSpeed[] = { 2000, 1000,  500,   250, 125,   60,  30,   15,      8,    4,   2,    1, T, B, AUTO600, AUTO100 };
 //                          0     1     2      3    4     5    6     7       8     9    10   11


### PR DESCRIPTION
ISO bug fix and solenoid power down adjustments for stm32 board version

I may attempt to revisit 328p power down settings at a later date. As it stands right now, leveraging the 328p's ADC for PWM in the arduino IDE provides less than satisfactory performance at lower duty cycles. Going any lower than the current powerdown value causes the solenoid to unlatch. This does not happen on the stm32.