### PR TITLE
Switch states

### DIFF
--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -412,7 +412,7 @@ void Camera::VariableManualExposure(int _myISO, uint8_t selector){
   return;
 }
 
-void Camera::AutoExposure(int _myISO, bool stopDown){
+void Camera::AutoExposure(int _myISO){
   if(stopDown){
     Camera::sol2Engage();
   }
@@ -437,9 +437,9 @@ void Camera::AutoExposure(int _myISO, bool stopDown){
   }
 
   Camera::ExposureFinish();
-
+  
    if(stopDown){
-    Camera::sol2Disengage();
+    Camera::sol2Engage();
   }
 
   return; //Added 26.10.

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -412,7 +412,7 @@ void Camera::VariableManualExposure(int _myISO, uint8_t selector){
   return;
 }
 
-void Camera::AutoExposure(int _myISO){
+void Camera::AutoExposure(int _myISO, bool stopDown){
   if(stopDown){
     Camera::sol2Engage();
   }
@@ -437,9 +437,9 @@ void Camera::AutoExposure(int _myISO){
   }
 
   Camera::ExposureFinish();
-  
+
    if(stopDown){
-    Camera::sol2Engage();
+    Camera::sol2Disengage();
   }
 
   return; //Added 26.10.

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -439,9 +439,10 @@ void Camera::AutoExposure(int _myISO){
 void Camera::AutoExposureFF(int _myISO){
   uint16_t FD_MN = 0;
   uint16_t FF_MN = 0;  //FlashDelay Magicnumber
+  
   if(_myISO == ISO_SX70){
-     FD_MN = FD100;
-     FF_MN = FF100;  
+    FD_MN = FD100;
+    FF_MN = FF100;  
   }
   else if(_myISO == ISO_600){
     FD_MN = FD600;
@@ -463,7 +464,8 @@ void Camera::AutoExposureFF(int _myISO){
   }
 
   meter_set_iso(FF_MN);
-  digitalWrite(PIN_FF, HIGH);  //FireFlash
+  //digitalWrite(PIN_FF, HIGH);  //FireFlash
+  FastFlash();
   delay(Flash_Capture_Delay);   //Capture Flash 
   uint32_t FFStartTime = millis();
   while (meter_update() == false){
@@ -472,9 +474,7 @@ void Camera::AutoExposureFF(int _myISO){
     }
   }
 
-  digitalWrite(PIN_FF, LOW);  //Turn FF off
   Camera::sol2Disengage();
-
   Camera::ExposureFinish();
 
   return; //Added 26.10.
@@ -558,7 +558,7 @@ void Camera::FastFlash(){
   pinMode(PIN_S2, OUTPUT);
   digitalWrite (PIN_S2, LOW);     //So FFA recognizes the flash as such
   digitalWrite(PIN_FF, HIGH);    //FLASH TRIGGERING
-  delay (1);                      //FLASH TRIGGERING
+  delay(1);
   digitalWrite(PIN_FF, LOW);     //FLASH TRIGGERING
   pinMode(PIN_S2, INPUT_PULLUP);  //S2 back to normal
 }

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -413,8 +413,15 @@ void Camera::VariableManualExposure(int _myISO, uint8_t selector){
 }
 
 void Camera::AutoExposure(int _myISO){
+  if(stopDown){
+    Camera::sol2Engage();
+  }
   
   delay(YDelay);
+
+  if(stopDown){
+    Camera::sol2LowPower();
+  }
 
   meter_set_iso(_myISO);
   meter_reset();
@@ -430,6 +437,10 @@ void Camera::AutoExposure(int _myISO){
   }
 
   Camera::ExposureFinish();
+  
+   if(stopDown){
+    Camera::sol2Engage();
+  }
 
   return; //Added 26.10.
 }

--- a/WORKING/opensx70_lib/camera_functions.cpp
+++ b/WORKING/opensx70_lib/camera_functions.cpp
@@ -413,15 +413,7 @@ void Camera::VariableManualExposure(int _myISO, uint8_t selector){
 }
 
 void Camera::AutoExposure(int _myISO){
-  if(stopDown){
-    Camera::sol2Engage();
-  }
-  
   delay(YDelay);
-
-  if(stopDown){
-    Camera::sol2LowPower();
-  }
 
   meter_set_iso(_myISO);
   meter_reset();
@@ -438,10 +430,6 @@ void Camera::AutoExposure(int _myISO){
 
   Camera::ExposureFinish();
   
-   if(stopDown){
-    Camera::sol2Engage();
-  }
-
   return; //Added 26.10.
 }
 

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -298,7 +298,7 @@ camera_state do_state_multi_exp (void){
 }
 
 void dongleFunctions(){
-  uint8_t isoSelection;
+  static uint16_t isoSelection;
   bool dongleAutoFlash = getSwitchStates(DONGLE_AUTO_FLASH);
 
   turnLedsOff();
@@ -313,18 +313,18 @@ void dongleFunctions(){
   }
   else{ //Auto catch-all. Passes the value stored in the ShutterSpeed list at the selector value
     switch(ShutterSpeed[current_status.selector]){
-    case AUTO100:
-      isoSelection = ISO_SX70;
-      break;
-    case AUTO600:
-      isoSelection = ISO_600;
-      break;
+      case AUTO600:
+        isoSelection = ISO_600;
+        break;
+      case AUTO100:
+        isoSelection = ISO_SX70;
+        break;
     } 
-    if(!dongleAutoFlash){
-      openSX70.AutoExposure(isoSelection);
+    if(dongleAutoFlash){
+      openSX70.AutoExposureFF(isoSelection);
     }
     else{
-      openSX70.AutoExposureFF(isoSelection);
+      openSX70.AutoExposure(isoSelection);
     }
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -146,7 +146,7 @@ camera_state do_state_noDongle (void){
   if ((sw_S1.clicks == -1) || (sw_S1.clicks == 1)){
     LightMeterHelper(0); 
     beginExposure();
-    openSX70.AutoExposure(savedISO);
+    openSX70.AutoExposure(savedISO, false);
     sw_S1.Reset();
   }
   #if DOUBLECLICK
@@ -154,7 +154,7 @@ camera_state do_state_noDongle (void){
     LightMeterHelper(0); 
     beginExposure();
     switch2Function(1);
-    openSX70.AutoExposure(savedISO);
+    openSX70.AutoExposure(savedISO, false);
     sw_S1.Reset();
   }
   #endif

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -184,8 +184,6 @@ camera_state do_state_noDongle (void){
 camera_state do_state_dongle (void){
   camera_state result = STATE_DONGLE;
   DongleInserted();
-  
-  bool selfTimerSwitchStatus = getSwitchStates(SELF_TIMER);
 
   if(ShutterSpeed[current_status.selector] == A100 || ShutterSpeed[current_status.selector] == A600){
     LightMeterHelper(1); //LMHelper Auto Mode
@@ -201,7 +199,7 @@ camera_state do_state_dongle (void){
     #endif
     LightMeterHelper(0);
 
-    if(current_status.switch2 == 1){
+    if(getSwitchStates(SELF_TIMER)){
       switch2Function(0); //switch2Function Manual Mode
     }
     beginExposure();
@@ -548,12 +546,9 @@ bool getSwitchStates(uint8_t switchValue){
   switch (switchValue){
     case 1:
       return current_status.switch1;
-      break;
     case 2:
       return current_status.switch2;
-      break;
     default:
       return false;
-      break;
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -321,7 +321,7 @@ void dongleFunctions(){
         break;
     } 
     if(!dongleAutoFlash){
-      openSX70.AutoExposure(isoSelection, getSwitchStates(AUTO_STOP_DOWN));
+      openSX70.AutoExposure(isoSelection);
     }
     else{
       openSX70.AutoExposureFF(isoSelection);

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -314,10 +314,10 @@ void dongleFunctions(){
   else{ //Auto catch-all. Passes the value stored in the ShutterSpeed list at the selector value
     switch(ShutterSpeed[current_status.selector]){
     case AUTO100:
-      isoSelection = openSX70.AutoExposure(ISO_SX70);
+      isoSelection = ISO_SX70;
       break;
     case AUTO600:
-      isoSelection = openSX70.AutoExposure(ISO_600);
+      isoSelection = ISO_600;
       break;
     } 
     if(!dongleAutoFlash){

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -298,7 +298,10 @@ camera_state do_state_multi_exp (void){
 }
 
 void dongleFunctions(){
-  turnLedsOff(); //why?
+  uint8_t isoSelection;
+  bool dongleAutoFlash = getSwitchStates(DONGLE_AUTO_FLASH);
+
+  turnLedsOff();
   if(current_status.selector<12){ //MANUAL SPEEDS  
     openSX70.ManualExposure(savedISO, current_status.selector);;
   }
@@ -311,12 +314,18 @@ void dongleFunctions(){
   else{ //Auto catch-all. Passes the value stored in the ShutterSpeed list at the selector value
     switch(ShutterSpeed[current_status.selector]){
     case AUTO100:
-      openSX70.AutoExposure(ISO_SX70);
+      isoSelection = openSX70.AutoExposure(ISO_SX70);
       break;
     case AUTO600:
-      openSX70.AutoExposure(ISO_600);
+      isoSelection = openSX70.AutoExposure(ISO_600);
       break;
     } 
+    if(!dongleAutoFlash){
+      openSX70.AutoExposure(isoSelection);
+    }
+    else{
+      openSX70.AutoExposureFF(isoSelection);
+    }
   }
 }
 

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -320,11 +320,11 @@ void dongleFunctions(){
         isoSelection = ISO_SX70;
         break;
     } 
-    if(dongleAutoFlash){
-      openSX70.AutoExposureFF(isoSelection);
+    if(!dongleAutoFlash){
+      openSX70.AutoExposure(isoSelection);
     }
     else{
-      openSX70.AutoExposure(isoSelection);
+      openSX70.AutoExposureFF(isoSelection);
     }
   }
 }

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -146,7 +146,7 @@ camera_state do_state_noDongle (void){
   if ((sw_S1.clicks == -1) || (sw_S1.clicks == 1)){
     LightMeterHelper(0); 
     beginExposure();
-    openSX70.AutoExposure(savedISO, false);
+    openSX70.AutoExposure(savedISO);
     sw_S1.Reset();
   }
   #if DOUBLECLICK
@@ -154,7 +154,7 @@ camera_state do_state_noDongle (void){
     LightMeterHelper(0); 
     beginExposure();
     switch2Function(1);
-    openSX70.AutoExposure(savedISO, false);
+    openSX70.AutoExposure(savedISO);
     sw_S1.Reset();
   }
   #endif

--- a/WORKING/opensx70_lib/opensx70_lib.ino
+++ b/WORKING/opensx70_lib/opensx70_lib.ino
@@ -321,7 +321,7 @@ void dongleFunctions(){
         break;
     } 
     if(!dongleAutoFlash){
-      openSX70.AutoExposure(isoSelection);
+      openSX70.AutoExposure(isoSelection, getSwitchStates(AUTO_STOP_DOWN));
     }
     else{
       openSX70.AutoExposureFF(isoSelection);

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -51,6 +51,7 @@
   #define MEXP_MODE 0
   #define SELF_TIMER 2
   #define DONGLE_AUTO_FLASH 1
+  #define AUTO_STOP_DOWN 0
 
   //----------------END DONGLE SWITCH FEATURE SELECTION---------------------
 

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -48,8 +48,9 @@
   // When I have a configurator style dongle set up I will be doing validation on that side.
   // Until then, YOU will need to validate that you are not overloading a switch.
 
-  #define MEXP_MODE 1
+  #define MEXP_MODE 0
   #define SELF_TIMER 2
+  #define DONGLE_AUTO_FLASH 1
 
   //----------------END DONGLE SWITCH FEATURE SELECTION---------------------
 

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -37,6 +37,18 @@
   #define EJECT_AFTER_DEPRESSING 1 //1 Enables the user to hold the shutter button to prevent photo ejection
   //----------------END CAMERA PCB OPTIONS SELECTION------------------------
 
+  //----------------DONGLE SWITCH FEATURE SELECTION-------------------------
+  // 1 and 2 values assign features to switch 1 and 2, 0 means unused.
+  // Example values:
+  // #define MEXP_MODE 1   : MEXP_MODE on switch 1
+  // #define SELF_TIMER 2  : SELF_TIMER on switch 2
+  // #define {whatever} 0  : No switch assigned. 
+
+  #define MEXP_MODE 1
+  #define SELF_TIMER 2
+
+  //----------------END DONGLE SWITCH FEATURE SELECTION---------------------
+
   //----------------ISO VALUES VALUES---------------------------------------
   #define ISO_600 640
   #define ISO_SX70 125

--- a/WORKING/opensx70_lib/settings.h
+++ b/WORKING/opensx70_lib/settings.h
@@ -43,6 +43,10 @@
   // #define MEXP_MODE 1   : MEXP_MODE on switch 1
   // #define SELF_TIMER 2  : SELF_TIMER on switch 2
   // #define {whatever} 0  : No switch assigned. 
+  // DO NOT ASSIGN MULTIPLE THINGS TO THE SAME VALUE (except 0).
+  // DOING SO WILL BREAK THINGS. YOU CANNOT HAVE MULTIPLE FUNCTIONS ASSIGNED TO THE SAME SWITCH.
+  // When I have a configurator style dongle set up I will be doing validation on that side.
+  // Until then, YOU will need to validate that you are not overloading a switch.
 
   #define MEXP_MODE 1
   #define SELF_TIMER 2


### PR DESCRIPTION
This update changes how the dongle switches are interpreted. Rather than just being MEXP and Self timer modes, you can now assign functions to the switches directly for added customization.