### PR TITLE
Small fixes

### DIFF
--- a/OpenSX70 Core/opensx70_lib/opensx70_lib.ino
+++ b/OpenSX70 Core/opensx70_lib/opensx70_lib.ino
@@ -279,6 +279,7 @@ void switch2Function(int mode) {
 
         // TODO: rewrite self timer to use new dongle functionality
 
+        digitalWrite(PIN_S1F_FBW, LOW);
         sendCommand(PERIPHERAL_SELF_TIMER_CMD);
         delay(4000);
         openSX70.shutterCLOSE();
@@ -356,11 +357,9 @@ void S1ISOSwap(){
             _selectedISO = ISO_600;
         }
         saveISO(_selectedISO);
-        while(digitalRead(PIN_S1) == HIGH){
-            //wait....
-        }
     }
     ISOBlink();
+    while(digitalRead(PIN_S1) == HIGH);
     sw_S1.Reset();
 }
 

--- a/OpenSX70 Core/opensx70_lib/opensx70_meter.cpp
+++ b/OpenSX70 Core/opensx70_lib/opensx70_meter.cpp
@@ -1,5 +1,6 @@
 #include "open_sx70.h"
 
+extern HardwareSerial DEBUG_OUTPUT;
 
 volatile bool integrationFinished = 0;
 
@@ -116,7 +117,7 @@ void meter_led(byte _selector, byte _type){
     }
 
     else if(_type == 1){ // Automode
-        if(predictedMillis >= ShutterSpeed[7]){ //Low light warning
+        if(predictedMillis >= ShutterSpeed[8]){ //Low light warning
             digitalWrite(PIN_LED1, HIGH);
             digitalWrite(PIN_LED2, LOW);
             #if LMHELPERDEBUG


### PR DESCRIPTION
Fixes a bug where the low light indicator function would mostly always be on for SX-70 modes.

Fixes a bug where sonar cameras would not properly focus during self timer modes

Changed when S1 ISO swap blinks LED to indicate the new ISO